### PR TITLE
Removed " from HEALTHCHECK command

### DIFF
--- a/clamav/0.104/alpine/Dockerfile
+++ b/clamav/0.104/alpine/Dockerfile
@@ -135,6 +135,6 @@ COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
 
-HEALTHCHECK --start-period=6m CMD "clamdcheck.sh"
+HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 
 ENTRYPOINT [ "/init" ]

--- a/clamav/0.105/alpine/Dockerfile
+++ b/clamav/0.105/alpine/Dockerfile
@@ -137,6 +137,6 @@ COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
 
-HEALTHCHECK --start-period=6m CMD "clamdcheck.sh"
+HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 
 ENTRYPOINT [ "/init" ]

--- a/clamav/0.105/debian/Dockerfile
+++ b/clamav/0.105/debian/Dockerfile
@@ -129,6 +129,6 @@ COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
 
-HEALTHCHECK --start-period=6m CMD "clamdcheck.sh"
+HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 
 ENTRYPOINT [ "/init" ]

--- a/clamav/1.0/alpine/Dockerfile
+++ b/clamav/1.0/alpine/Dockerfile
@@ -137,6 +137,6 @@ COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
 
-HEALTHCHECK --start-period=6m CMD "clamdcheck.sh"
+HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 
 ENTRYPOINT [ "/init" ]

--- a/clamav/1.0/debian/Dockerfile
+++ b/clamav/1.0/debian/Dockerfile
@@ -129,6 +129,6 @@ COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
 
-HEALTHCHECK --start-period=6m CMD "clamdcheck.sh"
+HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 
 ENTRYPOINT [ "/init" ]

--- a/clamav/unstable/alpine/Dockerfile
+++ b/clamav/unstable/alpine/Dockerfile
@@ -137,6 +137,6 @@ COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
 
-HEALTHCHECK --start-period=6m CMD "clamdcheck.sh"
+HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 
 ENTRYPOINT [ "/init" ]

--- a/clamav/unstable/debian/Dockerfile
+++ b/clamav/unstable/debian/Dockerfile
@@ -129,6 +129,6 @@ COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
 
-HEALTHCHECK --start-period=6m CMD "clamdcheck.sh"
+HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 
 ENTRYPOINT [ "/init" ]


### PR DESCRIPTION
because container healthcheck fails in at least podman with " around the command to execute.



 
Both stable and unstable official docker images has defined a healthcheck command that fails. `podman image inspect` reveals it defined as

```Shell
{
  "Test": [
    "CMD-SHELL",
    "\"clamdcheck.sh\""
  ],
  "StartPeriod": 360000000000
}
```

After starting a container based on either image `podman ps` will reveal a (starting), where as my other containers has a (healthy) in the STATUS column. 

If I attempt to run the healthcheck then it also fails
```Shell
podman healthcheck run dmz-clamav
Error: healthcheck command exceeded timeout of 0s
```



It will continue to have this (starting) even long after clamd has started.

```Shell
podman logs dmz-clamav
...
socket found, clamd started.
```

If I manually run `clamdcheck.sh` inside the container it works fine, but not when run as a container healthcheck.


The fix is rather easy, if I at container creation time add this parameter `--health-cmd="/usr/local/bin/clamdcheck.sh"` then `podman ps` will say (healthy) in the STATUS column, and the `podman healthcheck run dmz-clamav` will run as expected.

After doing that, `podman inspect` will reveal a slightly different definition

```Shell
podman container inspect dmz-clamav | jq '.[0].Config.Healthcheck' 
{
  "Test": [
    "CMD-SHELL",
    "/usr/local/bin/clamdcheck.sh"
  ],
  "Interval": 30000000000,
  "Timeout": 30000000000,
  "Retries": 3
}
```

The fix seems to work both with `--health-cmd="/usr/local/bin/clamdcheck.sh"` and `--health-cmd="clamdcheck.sh"`

Because my above test seemed to work and that [The official Dockerfile reference](https://docs.docker.com/engine/reference/builder/#healthcheck) has examples of HEALTHCHECK commands without " in it so it seemed totally safe to remove it, so I did that in all Dockerfile's I could find. 
