### PR TITLE
Allow setting the UID and GID of clamav at runtime

### DIFF
--- a/clamav/1.0/alpine/Dockerfile
+++ b/clamav/1.0/alpine/Dockerfile
@@ -35,6 +35,7 @@ RUN apk update && apk upgrade \
         # For building static libraries with Mussels
         git \
         patchelf \
+        shadow \
     && \
     python3 -m pip install --upgrade pip && \
     python3 -m pip install mussels && \

--- a/clamav/1.0/alpine/scripts/docker-entrypoint.sh
+++ b/clamav/1.0/alpine/scripts/docker-entrypoint.sh
@@ -10,6 +10,15 @@
 
 set -eu
 
+# update userid/groupid if specified
+if [ -n $CLAMAV_UID ]; then
+        usermod -u $CLAMAV_UID clamav
+fi
+
+if [ -n $CLAMAV_GID ]; then
+        groupmod -g $CLAMAV_GID clamav
+fi
+
 if [ ! -d "/run/clamav" ]; then
 	install -d -g "clamav" -m 775 -o "clamav" "/run/clamav"
 fi

--- a/clamav/1.0/debian/Dockerfile
+++ b/clamav/1.0/debian/Dockerfile
@@ -36,6 +36,7 @@ RUN apt update && apt install -y \
         libxml2-dev \
         zlib1g-dev \
         curl \
+        shadow \
     && \
     rm -rf /var/cache/apt/archives \
     && \

--- a/clamav/1.0/debian/scripts/docker-entrypoint.sh
+++ b/clamav/1.0/debian/scripts/docker-entrypoint.sh
@@ -10,6 +10,15 @@
 
 set -eu
 
+# update userid/groupid if specified
+if [ -n $CLAMAV_UID ]; then
+        usermod -u $CLAMAV_UID clamav
+fi
+
+if [ -n $CLAMAV_GID ]; then
+        groupmod -g $CLAMAV_GID clamav
+fi
+
 if [ ! -d "/run/clamav" ]; then
 	install -d -g "clamav" -m 775 -o "clamav" "/run/clamav"
 fi


### PR DESCRIPTION
If CLAMAV_UID/CLAMAV_GID are set, the userid and/or groupid of the clamav user is updated on startup. This can be helfull to gain the correct access rights on scandir mounts.