### PR TITLE
Multi-arch DB image fix & Copying unprivileged init script

### DIFF
--- a/clamav/1.0/alpine/Dockerfile
+++ b/clamav/1.0/alpine/Dockerfile
@@ -39,9 +39,9 @@ RUN apk update && apk upgrade \
         py3-pytest \
         # For Rust/Cargo
         cargo \
-        rust \
-    && \
-    mkdir -p "./build" && cd "./build" && \
+        rust
+
+RUN mkdir -p "./build" && cd "./build" && \
     cmake .. \
         -D CMAKE_BUILD_TYPE="Release"                                                       \
         -D CMAKE_INSTALL_PREFIX="/usr"                                                      \
@@ -109,9 +109,9 @@ RUN apk add --no-cache \
         libxml2 \
         ncurses-libs \
         pcre2 \
-        zlib \
-    && \
-    addgroup -S "clamav" && \
+        zlib
+
+RUN addgroup -S "clamav" && \
     adduser -D -G "clamav" -h "/var/lib/clamav" -s "/bin/false" -u 100 -S "clamav" && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
     chown -R clamav:clamav /var/lib/clamav

--- a/clamav/1.0/alpine/Dockerfile
+++ b/clamav/1.0/alpine/Dockerfile
@@ -119,6 +119,7 @@ RUN apk add --no-cache \
 COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
+COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unpriviledged"
 
 HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 

--- a/clamav/1.0/alpine/Dockerfile
+++ b/clamav/1.0/alpine/Dockerfile
@@ -119,7 +119,7 @@ RUN apk add --no-cache \
 COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
-COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unpriviledged"
+COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unprivileged"
 
 HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 

--- a/clamav/1.0/debian/Dockerfile
+++ b/clamav/1.0/debian/Dockerfile
@@ -129,7 +129,7 @@ COPY --from=builder "/clamav" "/"
 
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
-COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unpriviledged"
+COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unprivileged"
 
 HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 

--- a/clamav/1.0/debian/Dockerfile
+++ b/clamav/1.0/debian/Dockerfile
@@ -129,6 +129,7 @@ COPY --from=builder "/clamav" "/"
 
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
+COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unpriviledged"
 
 HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 

--- a/clamav/1.0/debian/Dockerfile
+++ b/clamav/1.0/debian/Dockerfile
@@ -44,9 +44,9 @@ RUN apt update && apt install -y \
     && \
     . $CARGO_HOME/env \
     && \
-    rustup update \
-    && \
-    mkdir -p "./build" && cd "./build" \
+    rustup update
+
+RUN mkdir -p "./build" && cd "./build" \
     && \
     cmake .. \
           -DCARGO_HOME=$CARGO_HOME \
@@ -119,8 +119,9 @@ RUN apt-get update && apt-get install -y \
         tzdata \
         netcat \
     && \
-    rm -rf /var/cache/apt/archives && \
-    groupadd -g 1000 "clamav" && \
+    rm -rf /var/cache/apt/archives
+
+RUN groupadd -g 1000 "clamav" && \
     useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 1000 -c "Clam Antivirus" clamav && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
     chown -R clamav:clamav /var/lib/clamav

--- a/clamav/1.0/debian/Jenkinsfile
+++ b/clamav/1.0/debian/Jenkinsfile
@@ -95,7 +95,7 @@ node('macos-newer') {
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
-                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_bas \
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
                     --push .
                     """
                 } else {

--- a/clamav/1.0/debian/Jenkinsfile
+++ b/clamav/1.0/debian/Jenkinsfile
@@ -87,37 +87,25 @@ node('macos-newer') {
                 //  - stable,   stable_base
                 //
 
-                // Build and push X.Y.Z-R_base image.
-                sh """
-                docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base --push .
-                """
-
-                // Pull X.Y.Z-R_base image in local registry for re-tagging
-                sh """
-                docker pull ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base
-                """
-
-                // Publish X.Y.Z_base tag
-                sh """
-                docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base
-                """
-
-                // Publish X.Y_base tag
-                sh """
-                docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base
-                """
-
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
-                    docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base
-
-                    docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base
+                    docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le \
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_bas \
+                    --push .
                     """
+                } else {
+                     sh """
+                        docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                        --push .
+                     """
                 }
 
                 // The update_db_image.sh script will query for tags during the update process.
@@ -140,27 +128,24 @@ node('macos-newer') {
                 """
 
                 // Publish X.Y.Z tag (without the _base suffix)
-                sh """
-                docker pull ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}
-                docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}
-                """
-
-                // Publish X.Y tag (without the _base suffix)
-                sh """
-                docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
-                """
 
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable' and 'latest' tags.
                     sh """
-                    docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable
-
-                    docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
+                        docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
                     """
+                } else {
+                    sh """
+                        docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
+
+                    """
+
                 }
 
                 // log-out (again)

--- a/clamav/1.0/debian/scripts/update_db_image.sh
+++ b/clamav/1.0/debian/scripts/update_db_image.sh
@@ -90,7 +90,8 @@ clamav_db_update() {
       # Update the database
       echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
     } | \
-      docker buildx build --platform linux/amd64 --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
+      docker buildx build --platform linux/amd64 --pull --rm --push \
+        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
 
     {
       # Starting with the image tag with the _base suffix
@@ -98,7 +99,8 @@ clamav_db_update() {
       # Update the database
       echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
     } | \
-      docker buildx build --platform linux/arm64 --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
+      docker buildx build --platform linux/arm64 --pull --rm --push \
+        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
 
     {
       # Starting with the image tag with the _base suffix
@@ -106,7 +108,8 @@ clamav_db_update() {
       # Update the database
       echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
     } | \
-      docker buildx build --platform linux/ppc64le --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
+      docker buildx build --platform linux/ppc64le --pull --rm --push \
+        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
 
   done
 

--- a/clamav/1.0/debian/scripts/update_db_image.sh
+++ b/clamav/1.0/debian/scripts/update_db_image.sh
@@ -11,101 +11,86 @@ DEF_CLAMAV_DOCKER_IMAGE="clamav"
 DEF_DOCKER_REGISTRY="registry.hub.docker.com"
 DOCKER_BUILDKIT_IMAGE="multiarch/qemu-user-static"
 
-
-usage()
-{
-	echo "Usage: ${0} [OPTIONS]"
-	echo "Update docker images with latest clamav database."
-	echo "    -h  Print this usage"
-	echo "    -n  Namespace to use to use (default: '${DEF_CLAMAV_DOCKER_NAMESPACE}') [CLAMAV_DOCKER_NAMESPACE]"
-	echo "    -i  Image to use to use (default: '${DEF_CLAMAV_DOCKER_IMAGE}') [CLAMAV_DOCKER_IMAGE]"
-	echo "    -p  Password for docker registry (file or string) [DOCKER_PASSWD]"
-	echo "    -r  Registry to use to push docker images to (default: '${DEF_DOCKER_REGISTRY}') [DOCKER_REGISTRY]"
-	echo "    -t  Tag(s) WITH _base suffix to update (default: all tags)"
-	echo "    -u  Username for docker registry [DOCKER_USER]"
-	echo
-	echo "Options that can also be passed in environment variables listed between [BRACKETS]."
+usage() {
+  echo "Usage: ${0} [OPTIONS]"
+  echo "Update docker images with latest clamav database."
+  echo "    -h  Print this usage"
+  echo "    -n  Namespace to use to use (default: '${DEF_CLAMAV_DOCKER_NAMESPACE}') [CLAMAV_DOCKER_NAMESPACE]"
+  echo "    -i  Image to use to use (default: '${DEF_CLAMAV_DOCKER_IMAGE}') [CLAMAV_DOCKER_IMAGE]"
+  echo "    -p  Password for docker registry (file or string) [DOCKER_PASSWD]"
+  echo "    -r  Registry to use to push docker images to (default: '${DEF_DOCKER_REGISTRY}') [DOCKER_REGISTRY]"
+  echo "    -t  Tag(s) WITH _base suffix to update (default: all tags)"
+  echo "    -u  Username for docker registry [DOCKER_USER]"
+  echo
+  echo "Options that can also be passed in environment variables listed between [BRACKETS]."
 }
 
-init()
-{
-	if [ -z "${clamav_docker_user:-}" ] ||
-           [ -z "${clamav_docker_passwd:-}" ]; then
-		echo "No username or password set, skipping login"
-		return
-	fi
+init() {
+  if [ -z "${clamav_docker_user:-}" ] ||
+    [ -z "${clamav_docker_passwd:-}" ]; then
+    echo "No username or password set, skipping login"
+    return
+  fi
 
-	docker --version
+  docker --version
 
-	if [ -f "${clamav_docker_passwd}" ]; then
-		_passwd="$(cat "${clamav_docker_passwd}")"
-	fi
-	echo "${_passwd:-${clamav_docker_passwd}}" | \
-	docker login \
-		--password-stdin \
-		--username "${clamav_docker_user}" \
-		"${docker_registry}"
+  if [ -f "${clamav_docker_passwd}" ]; then
+    _passwd="$(cat "${clamav_docker_passwd}")"
+  fi
+  echo "${_passwd:-${clamav_docker_passwd}}" |
+    docker login \
+      --password-stdin \
+      --username "${clamav_docker_user}" \
+      "${docker_registry}"
 }
 
-cleanup()
-{
-	if [ -z "${clamav_docker_user:-}" ]; then
-		echo "No username set, skipping logout"
-		return
-	fi
+cleanup() {
+  if [ -z "${clamav_docker_user:-}" ]; then
+    echo "No username set, skipping logout"
+    return
+  fi
 
-	docker logout "${docker_registry:-}"
+  docker logout "${docker_registry:-}"
 }
 
-docker_tags_get()
-{
-	_tags="$(wget -q -O - "https://${docker_registry}/v2/namespaces/${clamav_docker_namespace}/repositories/${clamav_docker_image}/tags" |
-	         sed -e 's|[][]||g' -e 's|"||g' -e 's| ||g' | \
-		 tr '}' '\n' | \
-		 sed -n -e 's|.*name:\(.*\)$|\1|p')"
+docker_tags_get() {
+  _tags="$(wget -q -O - "https://${docker_registry}/v2/namespaces/${clamav_docker_namespace}/repositories/${clamav_docker_image}/tags" |
+    sed -e 's|[][]||g' -e 's|"||g' -e 's| ||g' |
+    tr '}' '\n' |
+    sed -n -e 's|.*name:\(.*\)$|\1|p')"
 
-	echo "Tags:"
-	echo "${_tags}"
+  echo "Tags:"
+  echo "${_tags}"
 
-	for _tag in ${_tags}; do
-		# Only get the tags that have the _base suffix
-		if [ "${_tag%%_base}" != "${_tag}" ]; then
-			clamav_docker_tags="${_tag} ${clamav_docker_tags:-}"
-		fi
-	done
+  for _tag in ${_tags}; do
+    # Only get the tags that have the _base suffix
+    if [ "${_tag%%_base}" != "${_tag}" ]; then
+      clamav_docker_tags="${_tag} ${clamav_docker_tags:-}"
+    fi
+  done
 
-	echo "Tags:"
-	echo "${clamav_docker_tags}"
+  echo "Tags:"
+  echo "${clamav_docker_tags}"
 }
 
-config_docker_buildx()
-{
+config_docker_buildx() {
   docker buildx use "clamav-test-mul-arch"
 }
 
-clamav_db_update()
-{
-	if [ -z "${clamav_docker_tags:-}" ]; then
-		echo "No tags to update with, cannot continue."
-		exit 1
-	fi
+clamav_db_update() {
+  if [ -z "${clamav_docker_tags:-}" ]; then
+    echo "No tags to update with, cannot continue."
+    exit 1
+  fi
 
-	for _tag in ${clamav_docker_tags}; do
-		{
-			# Starting with the image tag with the _base suffix
-			echo "FROM ${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag}"
-			# Update the database
-			echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
-		} | \
-		docker buildx build --platform linux/amd64 --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
-
+  for _tag in ${clamav_docker_tags}; do
     {
-			# Starting with the image tag with the _base suffix
-			echo "FROM ${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag}"
-			# Update the database
-			echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
-		} | \
-		docker buildx build --platform linux/arm64 --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
+      # Starting with the image tag with the _base suffix
+      echo "FROM ${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag}"
+      # Update the database
+      echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
+    } | \
+      docker buildx build --platform linux/amd64 --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
 
     {
       # Starting with the image tag with the _base suffix
@@ -113,84 +98,91 @@ clamav_db_update()
       # Update the database
       echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
     } | \
-		docker buildx build --platform linux/ppc64le --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
+      docker buildx build --platform linux/arm64 --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
 
-	done
+    {
+      # Starting with the image tag with the _base suffix
+      echo "FROM ${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag}"
+      # Update the database
+      echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
+    } | \
+      docker buildx build --platform linux/ppc64le --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
 
-  docker buildx imagetools  create -t  "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
-           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
-           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
-           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
+  done
+
+  docker buildx imagetools create -t "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
+    "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
+    "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
+    "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
 }
 
-main()
-{
-	_start_time="$(date "+%s")"
+main() {
+  _start_time="$(date "+%s")"
 
-	while getopts ":hi:n:p:r:t:u:" _options; do
-		case "${_options}" in
-		h)
-			usage
-			exit 0
-			;;
-		i)
-			clamav_docker_image="${OPTARG}"
-			;;
-		n)
-			clamav_docker_namespace="${OPTARG}"
-			;;
-		p)
-			clamav_docker_passwd="${OPTARG}"
-			;;
-		r)
-			docker_registry="${OPTARG}"
-			;;
-		t)
-			clamav_docker_tag="${OPTARG}"
-			;;
-		u)
-			clamav_docker_user="${OPTARG}"
-			;;
-		:)
-			>&2 echo "Option -${OPTARG} requires an argument."
-			exit 1
-			;;
-		?)
-			>&2 echo "Invalid option: -${OPTARG}"
-			exit 1
-			;;
-		esac
-	done
-	shift "$((OPTIND - 1))"
+  while getopts ":hi:n:p:r:t:u:" _options; do
+    case "${_options}" in
+    h)
+      usage
+      exit 0
+      ;;
+    i)
+      clamav_docker_image="${OPTARG}"
+      ;;
+    n)
+      clamav_docker_namespace="${OPTARG}"
+      ;;
+    p)
+      clamav_docker_passwd="${OPTARG}"
+      ;;
+    r)
+      docker_registry="${OPTARG}"
+      ;;
+    t)
+      clamav_docker_tag="${OPTARG}"
+      ;;
+    u)
+      clamav_docker_user="${OPTARG}"
+      ;;
+    :)
+      echo >&2 "Option -${OPTARG} requires an argument."
+      exit 1
+      ;;
+    ?)
+      echo >&2 "Invalid option: -${OPTARG}"
+      exit 1
+      ;;
+    esac
+  done
+  shift "$((OPTIND - 1))"
 
-	clamav_docker_namespace="${clamav_docker_namespace:-${CLAMAV_DOCKER_NAMESPACE:-${DEF_CLAMAV_DOCKER_NAMESPACE}}}"
-	clamav_docker_image="${clamav_docker_image:-${CLAMAV_DOCKER_IMAGE:-${DEF_CLAMAV_DOCKER_IMAGE}}}"
-	clamav_docker_passwd="${clamav_docker_passwd:-${DOCKER_PASSWD:-}}"
-	clamav_docker_tag="${clamav_docker_tag:-}"
-	clamav_docker_user="${clamav_docker_user:-${DOCKER_USER:-}}"
-	docker_registry="${docker_registry:-${DOCKER_REGISTRY:-${DEF_DOCKER_REGISTRY}}}"
+  clamav_docker_namespace="${clamav_docker_namespace:-${CLAMAV_DOCKER_NAMESPACE:-${DEF_CLAMAV_DOCKER_NAMESPACE}}}"
+  clamav_docker_image="${clamav_docker_image:-${CLAMAV_DOCKER_IMAGE:-${DEF_CLAMAV_DOCKER_IMAGE}}}"
+  clamav_docker_passwd="${clamav_docker_passwd:-${DOCKER_PASSWD:-}}"
+  clamav_docker_tag="${clamav_docker_tag:-}"
+  clamav_docker_user="${clamav_docker_user:-${DOCKER_USER:-}}"
+  docker_registry="${docker_registry:-${DOCKER_REGISTRY:-${DEF_DOCKER_REGISTRY}}}"
 
-	init
-	config_docker_buildx
+  init
+  config_docker_buildx
 
-	if [ -n "${clamav_docker_tag}" ]; then
-		clamav_docker_tags="${clamav_docker_tag}"
-	else
-		docker_tags_get
-	fi
+  if [ -n "${clamav_docker_tag}" ]; then
+    clamav_docker_tags="${clamav_docker_tag}"
+  else
+    docker_tags_get
+  fi
 
-	clamav_db_update
+  clamav_db_update
 
-	echo "==============================================================================="
-	echo "Build report for $(date -u)"
-	echo
-	echo "Updated database for image tags ..."
-	echo "${clamav_docker_tags:-}"
-	echo
-	echo "... successfully in $(($(date "+%s") - _start_time)) seconds"
-	echo "==============================================================================="
+  echo "==============================================================================="
+  echo "Build report for $(date -u)"
+  echo
+  echo "Updated database for image tags ..."
+  echo "${clamav_docker_tags:-}"
+  echo
+  echo "... successfully in $(($(date "+%s") - _start_time)) seconds"
+  echo "==============================================================================="
 
-	cleanup
+  cleanup
 }
 
 main "${@}"

--- a/clamav/1.0/debian/scripts/update_db_image.sh
+++ b/clamav/1.0/debian/scripts/update_db_image.sh
@@ -99,8 +99,17 @@ clamav_db_update()
 		} | \
 		# Pull and Build the updated image with the tag without the _base suffix.
 		# Also push it to the registry.
-		docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le --pull --push --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" -
+		docker buildx build --platform linux/amd64 --pull --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
+		docker buildx build --platform linux/arm64 --pull --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
+		docker buildx build --platform linux/ppc64le --pull --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
 	done
+
+	docker manifest create "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
+           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
+           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
+           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
+
+	docker manifest push --purge "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}"
 }
 
 main()

--- a/clamav/1.0/debian/scripts/update_db_image.sh
+++ b/clamav/1.0/debian/scripts/update_db_image.sh
@@ -117,12 +117,10 @@ clamav_db_update()
 
 	done
 
-	docker manifest create "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
-           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
-           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
-           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
-
-	docker manifest push --purge "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}"
+  docker buildx imagetools  create -t  "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
+           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
+           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
+           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
 }
 
 main()

--- a/clamav/1.1/alpine/Dockerfile
+++ b/clamav/1.1/alpine/Dockerfile
@@ -39,9 +39,9 @@ RUN apk update && apk upgrade \
         py3-pytest \
         # For Rust/Cargo
         cargo \
-        rust \
-    && \
-    mkdir -p "./build" && cd "./build" && \
+        rust
+
+RUN mkdir -p "./build" && cd "./build" && \
     cmake .. \
         -D CMAKE_BUILD_TYPE="Release"                                                       \
         -D CMAKE_INSTALL_PREFIX="/usr"                                                      \
@@ -109,9 +109,9 @@ RUN apk add --no-cache \
         libxml2 \
         ncurses-libs \
         pcre2 \
-        zlib \
-    && \
-    addgroup -S "clamav" && \
+        zlib
+
+RUN addgroup -S "clamav" && \
     adduser -D -G "clamav" -h "/var/lib/clamav" -s "/bin/false" -u 100 -S "clamav" && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
     chown -R clamav:clamav /var/lib/clamav

--- a/clamav/1.1/alpine/Dockerfile
+++ b/clamav/1.1/alpine/Dockerfile
@@ -119,6 +119,7 @@ RUN apk add --no-cache \
 COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
+COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unpriviledged"
 
 HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 

--- a/clamav/1.1/alpine/Dockerfile
+++ b/clamav/1.1/alpine/Dockerfile
@@ -119,7 +119,7 @@ RUN apk add --no-cache \
 COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
-COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unpriviledged"
+COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unprivileged"
 
 HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 

--- a/clamav/1.1/debian/Dockerfile
+++ b/clamav/1.1/debian/Dockerfile
@@ -129,7 +129,7 @@ COPY --from=builder "/clamav" "/"
 
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
-COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unpriviledged"
+COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unprivileged"
 
 HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 

--- a/clamav/1.1/debian/Dockerfile
+++ b/clamav/1.1/debian/Dockerfile
@@ -129,6 +129,7 @@ COPY --from=builder "/clamav" "/"
 
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
+COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unpriviledged"
 
 HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 

--- a/clamav/1.1/debian/Dockerfile
+++ b/clamav/1.1/debian/Dockerfile
@@ -44,9 +44,9 @@ RUN apt update && apt install -y \
     && \
     . $CARGO_HOME/env \
     && \
-    rustup update \
-    && \
-    mkdir -p "./build" && cd "./build" \
+    rustup update
+
+RUN mkdir -p "./build" && cd "./build" \
     && \
     cmake .. \
           -DCARGO_HOME=$CARGO_HOME \
@@ -119,8 +119,9 @@ RUN apt-get update && apt-get install -y \
         tzdata \
         netcat \
     && \
-    rm -rf /var/cache/apt/archives && \
-    groupadd -g 1000 "clamav" && \
+    rm -rf /var/cache/apt/archives
+
+RUN groupadd -g 1000 "clamav" && \
     useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 1000 -c "Clam Antivirus" clamav && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
     chown -R clamav:clamav /var/lib/clamav

--- a/clamav/1.1/debian/Jenkinsfile
+++ b/clamav/1.1/debian/Jenkinsfile
@@ -95,7 +95,7 @@ node('macos-newer') {
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
-                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_bas \
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
                     --push .
                     """
                 } else {

--- a/clamav/1.1/debian/Jenkinsfile
+++ b/clamav/1.1/debian/Jenkinsfile
@@ -87,37 +87,25 @@ node('macos-newer') {
                 //  - stable,   stable_base
                 //
 
-                // Build and push X.Y.Z-R_base image.
-                sh """
-                docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base --push .
-                """
-
-                // Pull X.Y.Z-R_base image in local registry for re-tagging
-                sh """
-                docker pull ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base
-                """
-
-                // Publish X.Y.Z_base tag
-                sh """
-                docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base
-                """
-
-                // Publish X.Y_base tag
-                sh """
-                docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base
-                """
-
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
-                    docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base
-
-                    docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base
+                    docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le \
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_bas \
+                    --push .
                     """
+                } else {
+                     sh """
+                        docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                        --push .
+                     """
                 }
 
                 // The update_db_image.sh script will query for tags during the update process.
@@ -140,27 +128,24 @@ node('macos-newer') {
                 """
 
                 // Publish X.Y.Z tag (without the _base suffix)
-                sh """
-                docker pull ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}
-                docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}
-                """
-
-                // Publish X.Y tag (without the _base suffix)
-                sh """
-                docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
-                """
 
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable' and 'latest' tags.
                     sh """
-                    docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable
-
-                    docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
+                        docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
                     """
+                } else {
+                    sh """
+                        docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
+
+                    """
+
                 }
 
                 // log-out (again)

--- a/clamav/1.1/debian/scripts/update_db_image.sh
+++ b/clamav/1.1/debian/scripts/update_db_image.sh
@@ -99,8 +99,17 @@ clamav_db_update()
 		} | \
 		# Pull and Build the updated image with the tag without the _base suffix.
 		# Also push it to the registry.
-		docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le --pull --push --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" -
+		docker buildx build --platform linux/amd64 --pull --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
+		docker buildx build --platform linux/arm64 --pull --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
+		docker buildx build --platform linux/ppc64le --pull --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
 	done
+
+	docker manifest create "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
+           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
+           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
+           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
+
+	docker manifest push --purge "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}"
 }
 
 main()

--- a/clamav/1.1/debian/scripts/update_db_image.sh
+++ b/clamav/1.1/debian/scripts/update_db_image.sh
@@ -117,12 +117,10 @@ clamav_db_update()
 
 	done
 
-	docker manifest create "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
-           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
-           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
-           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
-
-	docker manifest push --purge "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}"
+  docker buildx imagetools  create -t  "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
+           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
+           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
+           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
 }
 
 main()

--- a/clamav/1.1/debian/scripts/update_db_image.sh
+++ b/clamav/1.1/debian/scripts/update_db_image.sh
@@ -11,101 +11,87 @@ DEF_CLAMAV_DOCKER_IMAGE="clamav"
 DEF_DOCKER_REGISTRY="registry.hub.docker.com"
 DOCKER_BUILDKIT_IMAGE="multiarch/qemu-user-static"
 
-
-usage()
-{
-	echo "Usage: ${0} [OPTIONS]"
-	echo "Update docker images with latest clamav database."
-	echo "    -h  Print this usage"
-	echo "    -n  Namespace to use to use (default: '${DEF_CLAMAV_DOCKER_NAMESPACE}') [CLAMAV_DOCKER_NAMESPACE]"
-	echo "    -i  Image to use to use (default: '${DEF_CLAMAV_DOCKER_IMAGE}') [CLAMAV_DOCKER_IMAGE]"
-	echo "    -p  Password for docker registry (file or string) [DOCKER_PASSWD]"
-	echo "    -r  Registry to use to push docker images to (default: '${DEF_DOCKER_REGISTRY}') [DOCKER_REGISTRY]"
-	echo "    -t  Tag(s) WITH _base suffix to update (default: all tags)"
-	echo "    -u  Username for docker registry [DOCKER_USER]"
-	echo
-	echo "Options that can also be passed in environment variables listed between [BRACKETS]."
+usage() {
+  echo "Usage: ${0} [OPTIONS]"
+  echo "Update docker images with latest clamav database."
+  echo "    -h  Print this usage"
+  echo "    -n  Namespace to use to use (default: '${DEF_CLAMAV_DOCKER_NAMESPACE}') [CLAMAV_DOCKER_NAMESPACE]"
+  echo "    -i  Image to use to use (default: '${DEF_CLAMAV_DOCKER_IMAGE}') [CLAMAV_DOCKER_IMAGE]"
+  echo "    -p  Password for docker registry (file or string) [DOCKER_PASSWD]"
+  echo "    -r  Registry to use to push docker images to (default: '${DEF_DOCKER_REGISTRY}') [DOCKER_REGISTRY]"
+  echo "    -t  Tag(s) WITH _base suffix to update (default: all tags)"
+  echo "    -u  Username for docker registry [DOCKER_USER]"
+  echo
+  echo "Options that can also be passed in environment variables listed between [BRACKETS]."
 }
 
-init()
-{
-	if [ -z "${clamav_docker_user:-}" ] ||
-           [ -z "${clamav_docker_passwd:-}" ]; then
-		echo "No username or password set, skipping login"
-		return
-	fi
+init() {
+  if [ -z "${clamav_docker_user:-}" ] ||
+    [ -z "${clamav_docker_passwd:-}" ]; then
+    echo "No username or password set, skipping login"
+    return
+  fi
 
-	docker --version
+  docker --version
 
-	if [ -f "${clamav_docker_passwd}" ]; then
-		_passwd="$(cat "${clamav_docker_passwd}")"
-	fi
-	echo "${_passwd:-${clamav_docker_passwd}}" | \
-	docker login \
-		--password-stdin \
-		--username "${clamav_docker_user}" \
-		"${docker_registry}"
+  if [ -f "${clamav_docker_passwd}" ]; then
+    _passwd="$(cat "${clamav_docker_passwd}")"
+  fi
+  echo "${_passwd:-${clamav_docker_passwd}}" |
+    docker login \
+      --password-stdin \
+      --username "${clamav_docker_user}" \
+      "${docker_registry}"
 }
 
-cleanup()
-{
-	if [ -z "${clamav_docker_user:-}" ]; then
-		echo "No username set, skipping logout"
-		return
-	fi
+cleanup() {
+  if [ -z "${clamav_docker_user:-}" ]; then
+    echo "No username set, skipping logout"
+    return
+  fi
 
-	docker logout "${docker_registry:-}"
+  docker logout "${docker_registry:-}"
 }
 
-docker_tags_get()
-{
-	_tags="$(wget -q -O - "https://${docker_registry}/v2/namespaces/${clamav_docker_namespace}/repositories/${clamav_docker_image}/tags" |
-	         sed -e 's|[][]||g' -e 's|"||g' -e 's| ||g' | \
-		 tr '}' '\n' | \
-		 sed -n -e 's|.*name:\(.*\)$|\1|p')"
+docker_tags_get() {
+  _tags="$(wget -q -O - "https://${docker_registry}/v2/namespaces/${clamav_docker_namespace}/repositories/${clamav_docker_image}/tags" |
+    sed -e 's|[][]||g' -e 's|"||g' -e 's| ||g' |
+    tr '}' '\n' |
+    sed -n -e 's|.*name:\(.*\)$|\1|p')"
 
-	echo "Tags:"
-	echo "${_tags}"
+  echo "Tags:"
+  echo "${_tags}"
 
-	for _tag in ${_tags}; do
-		# Only get the tags that have the _base suffix
-		if [ "${_tag%%_base}" != "${_tag}" ]; then
-			clamav_docker_tags="${_tag} ${clamav_docker_tags:-}"
-		fi
-	done
+  for _tag in ${_tags}; do
+    # Only get the tags that have the _base suffix
+    if [ "${_tag%%_base}" != "${_tag}" ]; then
+      clamav_docker_tags="${_tag} ${clamav_docker_tags:-}"
+    fi
+  done
 
-	echo "Tags:"
-	echo "${clamav_docker_tags}"
+  echo "Tags:"
+  echo "${clamav_docker_tags}"
 }
 
-config_docker_buildx()
-{
+config_docker_buildx() {
   docker buildx use "clamav-test-mul-arch"
 }
 
-clamav_db_update()
-{
-	if [ -z "${clamav_docker_tags:-}" ]; then
-		echo "No tags to update with, cannot continue."
-		exit 1
-	fi
+clamav_db_update() {
+  if [ -z "${clamav_docker_tags:-}" ]; then
+    echo "No tags to update with, cannot continue."
+    exit 1
+  fi
 
-	for _tag in ${clamav_docker_tags}; do
-		{
-			# Starting with the image tag with the _base suffix
-			echo "FROM ${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag}"
-			# Update the database
-			echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
-		} | \
-		docker buildx build --platform linux/amd64 --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
-
+  for _tag in ${clamav_docker_tags}; do
     {
-			# Starting with the image tag with the _base suffix
-			echo "FROM ${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag}"
-			# Update the database
-			echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
-		} | \
-		docker buildx build --platform linux/arm64 --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
+      # Starting with the image tag with the _base suffix
+      echo "FROM ${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag}"
+      # Update the database
+      echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
+    } | \
+      docker buildx build --platform linux/amd64 --pull --rm --push \
+        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
 
     {
       # Starting with the image tag with the _base suffix
@@ -113,84 +99,93 @@ clamav_db_update()
       # Update the database
       echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
     } | \
-		docker buildx build --platform linux/ppc64le --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
+      docker buildx build --platform linux/arm64 --pull --rm --push \
+        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
 
-	done
+    {
+      # Starting with the image tag with the _base suffix
+      echo "FROM ${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag}"
+      # Update the database
+      echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
+    } | \
+      docker buildx build --platform linux/ppc64le --pull --rm --push \
+        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
 
-  docker buildx imagetools  create -t  "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
-           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
-           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
-           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
+  done
+
+  docker buildx imagetools create -t "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
+    "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
+    "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
+    "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
 }
 
-main()
-{
-	_start_time="$(date "+%s")"
+main() {
+  _start_time="$(date "+%s")"
 
-	while getopts ":hi:n:p:r:t:u:" _options; do
-		case "${_options}" in
-		h)
-			usage
-			exit 0
-			;;
-		i)
-			clamav_docker_image="${OPTARG}"
-			;;
-		n)
-			clamav_docker_namespace="${OPTARG}"
-			;;
-		p)
-			clamav_docker_passwd="${OPTARG}"
-			;;
-		r)
-			docker_registry="${OPTARG}"
-			;;
-		t)
-			clamav_docker_tag="${OPTARG}"
-			;;
-		u)
-			clamav_docker_user="${OPTARG}"
-			;;
-		:)
-			>&2 echo "Option -${OPTARG} requires an argument."
-			exit 1
-			;;
-		?)
-			>&2 echo "Invalid option: -${OPTARG}"
-			exit 1
-			;;
-		esac
-	done
-	shift "$((OPTIND - 1))"
+  while getopts ":hi:n:p:r:t:u:" _options; do
+    case "${_options}" in
+    h)
+      usage
+      exit 0
+      ;;
+    i)
+      clamav_docker_image="${OPTARG}"
+      ;;
+    n)
+      clamav_docker_namespace="${OPTARG}"
+      ;;
+    p)
+      clamav_docker_passwd="${OPTARG}"
+      ;;
+    r)
+      docker_registry="${OPTARG}"
+      ;;
+    t)
+      clamav_docker_tag="${OPTARG}"
+      ;;
+    u)
+      clamav_docker_user="${OPTARG}"
+      ;;
+    :)
+      echo >&2 "Option -${OPTARG} requires an argument."
+      exit 1
+      ;;
+    ?)
+      echo >&2 "Invalid option: -${OPTARG}"
+      exit 1
+      ;;
+    esac
+  done
+  shift "$((OPTIND - 1))"
 
-	clamav_docker_namespace="${clamav_docker_namespace:-${CLAMAV_DOCKER_NAMESPACE:-${DEF_CLAMAV_DOCKER_NAMESPACE}}}"
-	clamav_docker_image="${clamav_docker_image:-${CLAMAV_DOCKER_IMAGE:-${DEF_CLAMAV_DOCKER_IMAGE}}}"
-	clamav_docker_passwd="${clamav_docker_passwd:-${DOCKER_PASSWD:-}}"
-	clamav_docker_tag="${clamav_docker_tag:-}"
-	clamav_docker_user="${clamav_docker_user:-${DOCKER_USER:-}}"
-	docker_registry="${docker_registry:-${DOCKER_REGISTRY:-${DEF_DOCKER_REGISTRY}}}"
+  clamav_docker_namespace="${clamav_docker_namespace:-${CLAMAV_DOCKER_NAMESPACE:-${DEF_CLAMAV_DOCKER_NAMESPACE}}}"
+  clamav_docker_image="${clamav_docker_image:-${CLAMAV_DOCKER_IMAGE:-${DEF_CLAMAV_DOCKER_IMAGE}}}"
+  clamav_docker_passwd="${clamav_docker_passwd:-${DOCKER_PASSWD:-}}"
+  clamav_docker_tag="${clamav_docker_tag:-}"
+  clamav_docker_user="${clamav_docker_user:-${DOCKER_USER:-}}"
+  docker_registry="${docker_registry:-${DOCKER_REGISTRY:-${DEF_DOCKER_REGISTRY}}}"
 
-	init
-	config_docker_buildx
+  init
+  config_docker_buildx
 
-	if [ -n "${clamav_docker_tag}" ]; then
-		clamav_docker_tags="${clamav_docker_tag}"
-	else
-		docker_tags_get
-	fi
+  if [ -n "${clamav_docker_tag}" ]; then
+    clamav_docker_tags="${clamav_docker_tag}"
+  else
+    docker_tags_get
+  fi
 
-	clamav_db_update
+  clamav_db_update
 
-	echo "==============================================================================="
-	echo "Build report for $(date -u)"
-	echo
-	echo "Updated database for image tags ..."
-	echo "${clamav_docker_tags:-}"
-	echo
-	echo "... successfully in $(($(date "+%s") - _start_time)) seconds"
-	echo "==============================================================================="
+  echo "==============================================================================="
+  echo "Build report for $(date -u)"
+  echo
+  echo "Updated database for image tags ..."
+  echo "${clamav_docker_tags:-}"
+  echo
+  echo "... successfully in $(($(date "+%s") - _start_time)) seconds"
+  echo "==============================================================================="
 
-	cleanup
+  cleanup
 }
 
 main "${@}"

--- a/clamav/1.2/alpine/Dockerfile
+++ b/clamav/1.2/alpine/Dockerfile
@@ -39,9 +39,9 @@ RUN apk update && apk upgrade \
         py3-pytest \
         # For Rust/Cargo
         cargo \
-        rust \
-    && \
-    mkdir -p "./build" && cd "./build" && \
+        rust
+
+RUN mkdir -p "./build" && cd "./build" && \
     cmake .. \
         -D CMAKE_BUILD_TYPE="Release"                                                       \
         -D CMAKE_INSTALL_PREFIX="/usr"                                                      \
@@ -109,9 +109,9 @@ RUN apk add --no-cache \
         libxml2 \
         ncurses-libs \
         pcre2 \
-        zlib \
-    && \
-    addgroup -S "clamav" && \
+        zlib
+
+RUN addgroup -S "clamav" && \
     adduser -D -G "clamav" -h "/var/lib/clamav" -s "/bin/false" -u 100 -S "clamav" && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
     chown -R clamav:clamav /var/lib/clamav

--- a/clamav/1.2/alpine/Dockerfile
+++ b/clamav/1.2/alpine/Dockerfile
@@ -119,6 +119,7 @@ RUN apk add --no-cache \
 COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
+COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unpriviledged"
 
 HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 

--- a/clamav/1.2/alpine/Dockerfile
+++ b/clamav/1.2/alpine/Dockerfile
@@ -119,7 +119,7 @@ RUN apk add --no-cache \
 COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
-COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unpriviledged"
+COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unprivileged"
 
 HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 

--- a/clamav/1.2/debian/Dockerfile
+++ b/clamav/1.2/debian/Dockerfile
@@ -129,7 +129,7 @@ COPY --from=builder "/clamav" "/"
 
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
-COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unpriviledged"
+COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unprivileged"
 
 HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 

--- a/clamav/1.2/debian/Dockerfile
+++ b/clamav/1.2/debian/Dockerfile
@@ -129,6 +129,7 @@ COPY --from=builder "/clamav" "/"
 
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
+COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unpriviledged"
 
 HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 

--- a/clamav/1.2/debian/Dockerfile
+++ b/clamav/1.2/debian/Dockerfile
@@ -44,9 +44,9 @@ RUN apt update && apt install -y \
     && \
     . $CARGO_HOME/env \
     && \
-    rustup update \
-    && \
-    mkdir -p "./build" && cd "./build" \
+    rustup update
+
+RUN mkdir -p "./build" && cd "./build" \
     && \
     cmake .. \
           -DCARGO_HOME=$CARGO_HOME \
@@ -119,8 +119,9 @@ RUN apt-get update && apt-get install -y \
         tzdata \
         netcat \
     && \
-    rm -rf /var/cache/apt/archives && \
-    groupadd -g 1000 "clamav" && \
+    rm -rf /var/cache/apt/archives
+
+RUN groupadd -g 1000 "clamav" && \
     useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 1000 -c "Clam Antivirus" clamav && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
     chown -R clamav:clamav /var/lib/clamav

--- a/clamav/1.2/debian/Jenkinsfile
+++ b/clamav/1.2/debian/Jenkinsfile
@@ -95,7 +95,7 @@ node('macos-newer') {
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
-                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_bas \
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
                     --push .
                     """
                 } else {

--- a/clamav/1.2/debian/Jenkinsfile
+++ b/clamav/1.2/debian/Jenkinsfile
@@ -87,37 +87,25 @@ node('macos-newer') {
                 //  - stable,   stable_base
                 //
 
-                // Build and push X.Y.Z-R_base image.
-                sh """
-                docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base --push .
-                """
-
-                // Pull X.Y.Z-R_base image in local registry for re-tagging
-                sh """
-                docker pull ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base
-                """
-
-                // Publish X.Y.Z_base tag
-                sh """
-                docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base
-                """
-
-                // Publish X.Y_base tag
-                sh """
-                docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base
-                """
-
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
-                    docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base
-
-                    docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base
+                    docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le \
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_bas \
+                    --push .
                     """
+                } else {
+                     sh """
+                        docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                        --push .
+                     """
                 }
 
                 // The update_db_image.sh script will query for tags during the update process.
@@ -140,27 +128,24 @@ node('macos-newer') {
                 """
 
                 // Publish X.Y.Z tag (without the _base suffix)
-                sh """
-                docker pull ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}
-                docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}
-                """
-
-                // Publish X.Y tag (without the _base suffix)
-                sh """
-                docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
-                """
 
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable' and 'latest' tags.
                     sh """
-                    docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable
-
-                    docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
+                        docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
                     """
+                } else {
+                    sh """
+                        docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
+
+                    """
+
                 }
 
                 // log-out (again)

--- a/clamav/1.2/debian/scripts/update_db_image.sh
+++ b/clamav/1.2/debian/scripts/update_db_image.sh
@@ -99,8 +99,17 @@ clamav_db_update()
 		} | \
 		# Pull and Build the updated image with the tag without the _base suffix.
 		# Also push it to the registry.
-		docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le --pull --push --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" -
+		docker buildx build --platform linux/amd64 --pull --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
+		docker buildx build --platform linux/arm64 --pull --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
+		docker buildx build --platform linux/ppc64le --pull --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
 	done
+
+	docker manifest create "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
+           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
+           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
+           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
+
+	docker manifest push --purge "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}"
 }
 
 main()

--- a/clamav/1.2/debian/scripts/update_db_image.sh
+++ b/clamav/1.2/debian/scripts/update_db_image.sh
@@ -117,12 +117,10 @@ clamav_db_update()
 
 	done
 
-	docker manifest create "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
-           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
-           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
-           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
-
-	docker manifest push --purge "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}"
+  docker buildx imagetools  create -t  "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
+           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
+           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
+           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
 }
 
 main()

--- a/clamav/1.2/debian/scripts/update_db_image.sh
+++ b/clamav/1.2/debian/scripts/update_db_image.sh
@@ -11,101 +11,87 @@ DEF_CLAMAV_DOCKER_IMAGE="clamav"
 DEF_DOCKER_REGISTRY="registry.hub.docker.com"
 DOCKER_BUILDKIT_IMAGE="multiarch/qemu-user-static"
 
-
-usage()
-{
-	echo "Usage: ${0} [OPTIONS]"
-	echo "Update docker images with latest clamav database."
-	echo "    -h  Print this usage"
-	echo "    -n  Namespace to use to use (default: '${DEF_CLAMAV_DOCKER_NAMESPACE}') [CLAMAV_DOCKER_NAMESPACE]"
-	echo "    -i  Image to use to use (default: '${DEF_CLAMAV_DOCKER_IMAGE}') [CLAMAV_DOCKER_IMAGE]"
-	echo "    -p  Password for docker registry (file or string) [DOCKER_PASSWD]"
-	echo "    -r  Registry to use to push docker images to (default: '${DEF_DOCKER_REGISTRY}') [DOCKER_REGISTRY]"
-	echo "    -t  Tag(s) WITH _base suffix to update (default: all tags)"
-	echo "    -u  Username for docker registry [DOCKER_USER]"
-	echo
-	echo "Options that can also be passed in environment variables listed between [BRACKETS]."
+usage() {
+  echo "Usage: ${0} [OPTIONS]"
+  echo "Update docker images with latest clamav database."
+  echo "    -h  Print this usage"
+  echo "    -n  Namespace to use to use (default: '${DEF_CLAMAV_DOCKER_NAMESPACE}') [CLAMAV_DOCKER_NAMESPACE]"
+  echo "    -i  Image to use to use (default: '${DEF_CLAMAV_DOCKER_IMAGE}') [CLAMAV_DOCKER_IMAGE]"
+  echo "    -p  Password for docker registry (file or string) [DOCKER_PASSWD]"
+  echo "    -r  Registry to use to push docker images to (default: '${DEF_DOCKER_REGISTRY}') [DOCKER_REGISTRY]"
+  echo "    -t  Tag(s) WITH _base suffix to update (default: all tags)"
+  echo "    -u  Username for docker registry [DOCKER_USER]"
+  echo
+  echo "Options that can also be passed in environment variables listed between [BRACKETS]."
 }
 
-init()
-{
-	if [ -z "${clamav_docker_user:-}" ] ||
-           [ -z "${clamav_docker_passwd:-}" ]; then
-		echo "No username or password set, skipping login"
-		return
-	fi
+init() {
+  if [ -z "${clamav_docker_user:-}" ] ||
+    [ -z "${clamav_docker_passwd:-}" ]; then
+    echo "No username or password set, skipping login"
+    return
+  fi
 
-	docker --version
+  docker --version
 
-	if [ -f "${clamav_docker_passwd}" ]; then
-		_passwd="$(cat "${clamav_docker_passwd}")"
-	fi
-	echo "${_passwd:-${clamav_docker_passwd}}" | \
-	docker login \
-		--password-stdin \
-		--username "${clamav_docker_user}" \
-		"${docker_registry}"
+  if [ -f "${clamav_docker_passwd}" ]; then
+    _passwd="$(cat "${clamav_docker_passwd}")"
+  fi
+  echo "${_passwd:-${clamav_docker_passwd}}" |
+    docker login \
+      --password-stdin \
+      --username "${clamav_docker_user}" \
+      "${docker_registry}"
 }
 
-cleanup()
-{
-	if [ -z "${clamav_docker_user:-}" ]; then
-		echo "No username set, skipping logout"
-		return
-	fi
+cleanup() {
+  if [ -z "${clamav_docker_user:-}" ]; then
+    echo "No username set, skipping logout"
+    return
+  fi
 
-	docker logout "${docker_registry:-}"
+  docker logout "${docker_registry:-}"
 }
 
-docker_tags_get()
-{
-	_tags="$(wget -q -O - "https://${docker_registry}/v2/namespaces/${clamav_docker_namespace}/repositories/${clamav_docker_image}/tags" |
-	         sed -e 's|[][]||g' -e 's|"||g' -e 's| ||g' | \
-		 tr '}' '\n' | \
-		 sed -n -e 's|.*name:\(.*\)$|\1|p')"
+docker_tags_get() {
+  _tags="$(wget -q -O - "https://${docker_registry}/v2/namespaces/${clamav_docker_namespace}/repositories/${clamav_docker_image}/tags" |
+    sed -e 's|[][]||g' -e 's|"||g' -e 's| ||g' |
+    tr '}' '\n' |
+    sed -n -e 's|.*name:\(.*\)$|\1|p')"
 
-	echo "Tags:"
-	echo "${_tags}"
+  echo "Tags:"
+  echo "${_tags}"
 
-	for _tag in ${_tags}; do
-		# Only get the tags that have the _base suffix
-		if [ "${_tag%%_base}" != "${_tag}" ]; then
-			clamav_docker_tags="${_tag} ${clamav_docker_tags:-}"
-		fi
-	done
+  for _tag in ${_tags}; do
+    # Only get the tags that have the _base suffix
+    if [ "${_tag%%_base}" != "${_tag}" ]; then
+      clamav_docker_tags="${_tag} ${clamav_docker_tags:-}"
+    fi
+  done
 
-	echo "Tags:"
-	echo "${clamav_docker_tags}"
+  echo "Tags:"
+  echo "${clamav_docker_tags}"
 }
 
-config_docker_buildx()
-{
+config_docker_buildx() {
   docker buildx use "clamav-test-mul-arch"
 }
 
-clamav_db_update()
-{
-	if [ -z "${clamav_docker_tags:-}" ]; then
-		echo "No tags to update with, cannot continue."
-		exit 1
-	fi
+clamav_db_update() {
+  if [ -z "${clamav_docker_tags:-}" ]; then
+    echo "No tags to update with, cannot continue."
+    exit 1
+  fi
 
-	for _tag in ${clamav_docker_tags}; do
-		{
-			# Starting with the image tag with the _base suffix
-			echo "FROM ${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag}"
-			# Update the database
-			echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
-		} | \
-		docker buildx build --platform linux/amd64 --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
-
+  for _tag in ${clamav_docker_tags}; do
     {
-			# Starting with the image tag with the _base suffix
-			echo "FROM ${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag}"
-			# Update the database
-			echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
-		} | \
-		docker buildx build --platform linux/arm64 --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
+      # Starting with the image tag with the _base suffix
+      echo "FROM ${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag}"
+      # Update the database
+      echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
+    } | \
+      docker buildx build --platform linux/amd64 --pull --rm --push \
+        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
 
     {
       # Starting with the image tag with the _base suffix
@@ -113,84 +99,93 @@ clamav_db_update()
       # Update the database
       echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
     } | \
-		docker buildx build --platform linux/ppc64le --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
+      docker buildx build --platform linux/arm64 --pull --rm --push \
+        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
 
-	done
+    {
+      # Starting with the image tag with the _base suffix
+      echo "FROM ${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag}"
+      # Update the database
+      echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
+    } | \
+      docker buildx build --platform linux/ppc64le --pull --rm --push \
+        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
 
-  docker buildx imagetools  create -t  "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
-           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
-           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
-           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
+  done
+
+  docker buildx imagetools create -t "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
+    "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
+    "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
+    "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
 }
 
-main()
-{
-	_start_time="$(date "+%s")"
+main() {
+  _start_time="$(date "+%s")"
 
-	while getopts ":hi:n:p:r:t:u:" _options; do
-		case "${_options}" in
-		h)
-			usage
-			exit 0
-			;;
-		i)
-			clamav_docker_image="${OPTARG}"
-			;;
-		n)
-			clamav_docker_namespace="${OPTARG}"
-			;;
-		p)
-			clamav_docker_passwd="${OPTARG}"
-			;;
-		r)
-			docker_registry="${OPTARG}"
-			;;
-		t)
-			clamav_docker_tag="${OPTARG}"
-			;;
-		u)
-			clamav_docker_user="${OPTARG}"
-			;;
-		:)
-			>&2 echo "Option -${OPTARG} requires an argument."
-			exit 1
-			;;
-		?)
-			>&2 echo "Invalid option: -${OPTARG}"
-			exit 1
-			;;
-		esac
-	done
-	shift "$((OPTIND - 1))"
+  while getopts ":hi:n:p:r:t:u:" _options; do
+    case "${_options}" in
+    h)
+      usage
+      exit 0
+      ;;
+    i)
+      clamav_docker_image="${OPTARG}"
+      ;;
+    n)
+      clamav_docker_namespace="${OPTARG}"
+      ;;
+    p)
+      clamav_docker_passwd="${OPTARG}"
+      ;;
+    r)
+      docker_registry="${OPTARG}"
+      ;;
+    t)
+      clamav_docker_tag="${OPTARG}"
+      ;;
+    u)
+      clamav_docker_user="${OPTARG}"
+      ;;
+    :)
+      echo >&2 "Option -${OPTARG} requires an argument."
+      exit 1
+      ;;
+    ?)
+      echo >&2 "Invalid option: -${OPTARG}"
+      exit 1
+      ;;
+    esac
+  done
+  shift "$((OPTIND - 1))"
 
-	clamav_docker_namespace="${clamav_docker_namespace:-${CLAMAV_DOCKER_NAMESPACE:-${DEF_CLAMAV_DOCKER_NAMESPACE}}}"
-	clamav_docker_image="${clamav_docker_image:-${CLAMAV_DOCKER_IMAGE:-${DEF_CLAMAV_DOCKER_IMAGE}}}"
-	clamav_docker_passwd="${clamav_docker_passwd:-${DOCKER_PASSWD:-}}"
-	clamav_docker_tag="${clamav_docker_tag:-}"
-	clamav_docker_user="${clamav_docker_user:-${DOCKER_USER:-}}"
-	docker_registry="${docker_registry:-${DOCKER_REGISTRY:-${DEF_DOCKER_REGISTRY}}}"
+  clamav_docker_namespace="${clamav_docker_namespace:-${CLAMAV_DOCKER_NAMESPACE:-${DEF_CLAMAV_DOCKER_NAMESPACE}}}"
+  clamav_docker_image="${clamav_docker_image:-${CLAMAV_DOCKER_IMAGE:-${DEF_CLAMAV_DOCKER_IMAGE}}}"
+  clamav_docker_passwd="${clamav_docker_passwd:-${DOCKER_PASSWD:-}}"
+  clamav_docker_tag="${clamav_docker_tag:-}"
+  clamav_docker_user="${clamav_docker_user:-${DOCKER_USER:-}}"
+  docker_registry="${docker_registry:-${DOCKER_REGISTRY:-${DEF_DOCKER_REGISTRY}}}"
 
-	init
-	config_docker_buildx
+  init
+  config_docker_buildx
 
-	if [ -n "${clamav_docker_tag}" ]; then
-		clamav_docker_tags="${clamav_docker_tag}"
-	else
-		docker_tags_get
-	fi
+  if [ -n "${clamav_docker_tag}" ]; then
+    clamav_docker_tags="${clamav_docker_tag}"
+  else
+    docker_tags_get
+  fi
 
-	clamav_db_update
+  clamav_db_update
 
-	echo "==============================================================================="
-	echo "Build report for $(date -u)"
-	echo
-	echo "Updated database for image tags ..."
-	echo "${clamav_docker_tags:-}"
-	echo
-	echo "... successfully in $(($(date "+%s") - _start_time)) seconds"
-	echo "==============================================================================="
+  echo "==============================================================================="
+  echo "Build report for $(date -u)"
+  echo
+  echo "Updated database for image tags ..."
+  echo "${clamav_docker_tags:-}"
+  echo
+  echo "... successfully in $(($(date "+%s") - _start_time)) seconds"
+  echo "==============================================================================="
 
-	cleanup
+  cleanup
 }
 
 main "${@}"

--- a/clamav/README-alpine.md
+++ b/clamav/README-alpine.md
@@ -194,8 +194,8 @@ database volume, [here are some notes on how this might work](#multiple-containe
 
 ### Running ClamD using non-root user using --user and --entrypoint 
 
-You can run a container using a non-root user "clamav" with unprivileged entrypoint script.   
- Just run:
+You can run a container using the non-root user "clamav" with the unprivileged entrypoint script. To do this with Docker, you will need to add these two options: `--user "clamav" --entrypoint /init-unprivileged`
+For example:
 ```bash
 docker run -it --rm \
       --user "clamav"

--- a/clamav/README-alpine.md
+++ b/clamav/README-alpine.md
@@ -192,6 +192,18 @@ To do so, you have two options:
 If you're thinking about running multiple containers that share a single
 database volume, [here are some notes on how this might work](#multiple-containers-sharing-the-same-mounted-databases).
 
+### Running ClamD using non-root user using --user and --entrypoint 
+
+You can run a container using a non-root user "clamav" with unprivileged entrypoint script.   
+ Just run:
+```bash
+docker run -it --rm \
+      --user "clamav"
+      --entrypoint /init-unprivileged
+      --name "clam_container_01" \
+    clamav/clamav:unstable_base
+```
+
 ## Running Clam(D)Scan
 
 Scanning files using `clamscan` or `clamdscan` is possible in various ways with

--- a/clamav/README-debian.md
+++ b/clamav/README-debian.md
@@ -202,6 +202,18 @@ To do so, you have two options:
 If you're thinking about running multiple containers that share a single
 database volume, [here are some notes on how this might work](#multiple-containers-sharing-the-same-mounted-databases).
 
+### Running ClamD using non-root user using --user and --entrypoint 
+
+You can run a container using a non-root user "clamav" with unprivileged entrypoint script.   
+ Just run:
+```bash
+docker run -it --rm \
+      --user "clamav"
+      --entrypoint /init-unprivileged
+      --name "clam_container_01" \
+    clamav/clamav-debian:unstable_base
+```
+
 ## Running Clam(D)Scan
 
 Scanning files using `clamscan` or `clamdscan` is possible in various ways with

--- a/clamav/README-debian.md
+++ b/clamav/README-debian.md
@@ -204,8 +204,8 @@ database volume, [here are some notes on how this might work](#multiple-containe
 
 ### Running ClamD using non-root user using --user and --entrypoint 
 
-You can run a container using a non-root user "clamav" with unprivileged entrypoint script.   
- Just run:
+You can run a container using the non-root user "clamav" with the unprivileged entrypoint script. To do this with Docker, you will need to add these two options: `--user "clamav" --entrypoint /init-unprivileged`
+For example:
 ```bash
 docker run -it --rm \
       --user "clamav"

--- a/clamav/unstable/alpine/Dockerfile
+++ b/clamav/unstable/alpine/Dockerfile
@@ -39,9 +39,9 @@ RUN apk update && apk upgrade \
         py3-pytest \
         # For Rust/Cargo
         cargo \
-        rust \
-    && \
-    mkdir -p "./build" && cd "./build" && \
+        rust
+
+RUN mkdir -p "./build" && cd "./build" && \
     cmake .. \
         -D CMAKE_BUILD_TYPE="Release"                                                       \
         -D CMAKE_INSTALL_PREFIX="/usr"                                                      \
@@ -109,9 +109,9 @@ RUN apk add --no-cache \
         libxml2 \
         ncurses-libs \
         pcre2 \
-        zlib \
-    && \
-    addgroup -S "clamav" && \
+        zlib
+
+RUN addgroup -S "clamav" && \
     adduser -D -G "clamav" -h "/var/lib/clamav" -s "/bin/false" -u 100 -S "clamav" && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
     chown -R clamav:clamav /var/lib/clamav

--- a/clamav/unstable/alpine/Dockerfile
+++ b/clamav/unstable/alpine/Dockerfile
@@ -119,6 +119,7 @@ RUN apk add --no-cache \
 COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
+COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unpriviledged"
 
 HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 

--- a/clamav/unstable/alpine/Dockerfile
+++ b/clamav/unstable/alpine/Dockerfile
@@ -119,7 +119,7 @@ RUN apk add --no-cache \
 COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
-COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unpriviledged"
+COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unprivileged"
 
 HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 

--- a/clamav/unstable/debian/Dockerfile
+++ b/clamav/unstable/debian/Dockerfile
@@ -129,7 +129,7 @@ COPY --from=builder "/clamav" "/"
 
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
-COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unpriviledged"
+COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unprivileged"
 
 HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 

--- a/clamav/unstable/debian/Dockerfile
+++ b/clamav/unstable/debian/Dockerfile
@@ -129,6 +129,7 @@ COPY --from=builder "/clamav" "/"
 
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"
 COPY "./scripts/docker-entrypoint.sh" "/init"
+COPY "./scripts/docker-entrypoint-unprivileged.sh" "/init-unpriviledged"
 
 HEALTHCHECK --start-period=6m CMD clamdcheck.sh
 

--- a/clamav/unstable/debian/Dockerfile
+++ b/clamav/unstable/debian/Dockerfile
@@ -44,9 +44,9 @@ RUN apt update && apt install -y \
     && \
     . $CARGO_HOME/env \
     && \
-    rustup update \
-    && \
-    mkdir -p "./build" && cd "./build" \
+    rustup update
+
+RUN mkdir -p "./build" && cd "./build" \
     && \
     cmake .. \
           -DCARGO_HOME=$CARGO_HOME \
@@ -119,8 +119,9 @@ RUN apt-get update && apt-get install -y \
         tzdata \
         netcat \
     && \
-    rm -rf /var/cache/apt/archives && \
-    groupadd -g 1000 "clamav" && \
+    rm -rf /var/cache/apt/archives
+
+RUN groupadd -g 1000 "clamav" && \
     useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 1000 -c "Clam Antivirus" clamav && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
     chown -R clamav:clamav /var/lib/clamav

--- a/clamav/unstable/debian/scripts/update_db_image.sh
+++ b/clamav/unstable/debian/scripts/update_db_image.sh
@@ -99,8 +99,17 @@ clamav_db_update()
 		} | \
 		# Pull and Build the updated image with the tag without the _base suffix.
 		# Also push it to the registry.
-		docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le --pull --push --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" -
+		docker buildx build --platform linux/amd64 --pull --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
+		docker buildx build --platform linux/arm64 --pull --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
+		docker buildx build --platform linux/ppc64le --pull --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
 	done
+
+	docker manifest create "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
+           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
+           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
+           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
+
+	docker manifest push --purge "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}"
 }
 
 main()

--- a/clamav/unstable/debian/scripts/update_db_image.sh
+++ b/clamav/unstable/debian/scripts/update_db_image.sh
@@ -117,12 +117,10 @@ clamav_db_update()
 
 	done
 
-	docker manifest create "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
-           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
-           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
-           --amend "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
-
-	docker manifest push --purge "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}"
+  docker buildx imagetools  create -t  "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
+           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
+           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
+           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
 }
 
 main()

--- a/clamav/unstable/debian/scripts/update_db_image.sh
+++ b/clamav/unstable/debian/scripts/update_db_image.sh
@@ -11,101 +11,87 @@ DEF_CLAMAV_DOCKER_IMAGE="clamav"
 DEF_DOCKER_REGISTRY="registry.hub.docker.com"
 DOCKER_BUILDKIT_IMAGE="multiarch/qemu-user-static"
 
-
-usage()
-{
-	echo "Usage: ${0} [OPTIONS]"
-	echo "Update docker images with latest clamav database."
-	echo "    -h  Print this usage"
-	echo "    -n  Namespace to use to use (default: '${DEF_CLAMAV_DOCKER_NAMESPACE}') [CLAMAV_DOCKER_NAMESPACE]"
-	echo "    -i  Image to use to use (default: '${DEF_CLAMAV_DOCKER_IMAGE}') [CLAMAV_DOCKER_IMAGE]"
-	echo "    -p  Password for docker registry (file or string) [DOCKER_PASSWD]"
-	echo "    -r  Registry to use to push docker images to (default: '${DEF_DOCKER_REGISTRY}') [DOCKER_REGISTRY]"
-	echo "    -t  Tag(s) WITH _base suffix to update (default: all tags)"
-	echo "    -u  Username for docker registry [DOCKER_USER]"
-	echo
-	echo "Options that can also be passed in environment variables listed between [BRACKETS]."
+usage() {
+  echo "Usage: ${0} [OPTIONS]"
+  echo "Update docker images with latest clamav database."
+  echo "    -h  Print this usage"
+  echo "    -n  Namespace to use to use (default: '${DEF_CLAMAV_DOCKER_NAMESPACE}') [CLAMAV_DOCKER_NAMESPACE]"
+  echo "    -i  Image to use to use (default: '${DEF_CLAMAV_DOCKER_IMAGE}') [CLAMAV_DOCKER_IMAGE]"
+  echo "    -p  Password for docker registry (file or string) [DOCKER_PASSWD]"
+  echo "    -r  Registry to use to push docker images to (default: '${DEF_DOCKER_REGISTRY}') [DOCKER_REGISTRY]"
+  echo "    -t  Tag(s) WITH _base suffix to update (default: all tags)"
+  echo "    -u  Username for docker registry [DOCKER_USER]"
+  echo
+  echo "Options that can also be passed in environment variables listed between [BRACKETS]."
 }
 
-init()
-{
-	if [ -z "${clamav_docker_user:-}" ] ||
-           [ -z "${clamav_docker_passwd:-}" ]; then
-		echo "No username or password set, skipping login"
-		return
-	fi
+init() {
+  if [ -z "${clamav_docker_user:-}" ] ||
+    [ -z "${clamav_docker_passwd:-}" ]; then
+    echo "No username or password set, skipping login"
+    return
+  fi
 
-	docker --version
+  docker --version
 
-	if [ -f "${clamav_docker_passwd}" ]; then
-		_passwd="$(cat "${clamav_docker_passwd}")"
-	fi
-	echo "${_passwd:-${clamav_docker_passwd}}" | \
-	docker login \
-		--password-stdin \
-		--username "${clamav_docker_user}" \
-		"${docker_registry}"
+  if [ -f "${clamav_docker_passwd}" ]; then
+    _passwd="$(cat "${clamav_docker_passwd}")"
+  fi
+  echo "${_passwd:-${clamav_docker_passwd}}" |
+    docker login \
+      --password-stdin \
+      --username "${clamav_docker_user}" \
+      "${docker_registry}"
 }
 
-cleanup()
-{
-	if [ -z "${clamav_docker_user:-}" ]; then
-		echo "No username set, skipping logout"
-		return
-	fi
+cleanup() {
+  if [ -z "${clamav_docker_user:-}" ]; then
+    echo "No username set, skipping logout"
+    return
+  fi
 
-	docker logout "${docker_registry:-}"
+  docker logout "${docker_registry:-}"
 }
 
-docker_tags_get()
-{
-	_tags="$(wget -q -O - "https://${docker_registry}/v2/namespaces/${clamav_docker_namespace}/repositories/${clamav_docker_image}/tags" |
-	         sed -e 's|[][]||g' -e 's|"||g' -e 's| ||g' | \
-		 tr '}' '\n' | \
-		 sed -n -e 's|.*name:\(.*\)$|\1|p')"
+docker_tags_get() {
+  _tags="$(wget -q -O - "https://${docker_registry}/v2/namespaces/${clamav_docker_namespace}/repositories/${clamav_docker_image}/tags" |
+    sed -e 's|[][]||g' -e 's|"||g' -e 's| ||g' |
+    tr '}' '\n' |
+    sed -n -e 's|.*name:\(.*\)$|\1|p')"
 
 	echo "Tags:"
 	echo "${_tags}"
 
-	for _tag in ${_tags}; do
-		# Only get the tags that have the _base suffix
-		if [ "${_tag%%_base}" != "${_tag}" ]; then
-			clamav_docker_tags="${_tag} ${clamav_docker_tags:-}"
-		fi
-	done
+  for _tag in ${_tags}; do
+    # Only get the tags that have the _base suffix
+    if [ "${_tag%%_base}" != "${_tag}" ]; then
+      clamav_docker_tags="${_tag} ${clamav_docker_tags:-}"
+    fi
+  done
 
-	echo "Tags:"
-	echo "${clamav_docker_tags}"
+  echo "Tags:"
+  echo "${clamav_docker_tags}"
 }
 
-config_docker_buildx()
-{
+config_docker_buildx() {
   docker buildx use "clamav-test-mul-arch"
 }
 
-clamav_db_update()
-{
-	if [ -z "${clamav_docker_tags:-}" ]; then
-		echo "No tags to update with, cannot continue."
-		exit 1
-	fi
+clamav_db_update() {
+  if [ -z "${clamav_docker_tags:-}" ]; then
+    echo "No tags to update with, cannot continue."
+    exit 1
+  fi
 
-	for _tag in ${clamav_docker_tags}; do
-		{
-			# Starting with the image tag with the _base suffix
-			echo "FROM ${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag}"
-			# Update the database
-			echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
-		} | \
-		docker buildx build --platform linux/amd64 --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
-
+  for _tag in ${clamav_docker_tags}; do
     {
-			# Starting with the image tag with the _base suffix
-			echo "FROM ${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag}"
-			# Update the database
-			echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
-		} | \
-		docker buildx build --platform linux/arm64 --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
+      # Starting with the image tag with the _base suffix
+      echo "FROM ${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag}"
+      # Update the database
+      echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
+    } | \
+      docker buildx build --platform linux/amd64 --pull --rm --push \
+        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
 
     {
       # Starting with the image tag with the _base suffix
@@ -113,84 +99,93 @@ clamav_db_update()
       # Update the database
       echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
     } | \
-		docker buildx build --platform linux/ppc64le --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
+      docker buildx build --platform linux/arm64 --pull --rm --push \
+        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
 
-	done
+    {
+      # Starting with the image tag with the _base suffix
+      echo "FROM ${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag}"
+      # Update the database
+      echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
+    } | \
+      docker buildx build --platform linux/ppc64le --pull --rm --push \
+        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
 
-  docker buildx imagetools  create -t  "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
-           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
-           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
-           "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
+  done
+
+  docker buildx imagetools create -t "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \
+    "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" \
+    "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" \
+    "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le"
 }
 
-main()
-{
-	_start_time="$(date "+%s")"
+main() {
+  _start_time="$(date "+%s")"
 
-	while getopts ":hi:n:p:r:t:u:" _options; do
-		case "${_options}" in
-		h)
-			usage
-			exit 0
-			;;
-		i)
-			clamav_docker_image="${OPTARG}"
-			;;
-		n)
-			clamav_docker_namespace="${OPTARG}"
-			;;
-		p)
-			clamav_docker_passwd="${OPTARG}"
-			;;
-		r)
-			docker_registry="${OPTARG}"
-			;;
-		t)
-			clamav_docker_tag="${OPTARG}"
-			;;
-		u)
-			clamav_docker_user="${OPTARG}"
-			;;
-		:)
-			>&2 echo "Option -${OPTARG} requires an argument."
-			exit 1
-			;;
-		?)
-			>&2 echo "Invalid option: -${OPTARG}"
-			exit 1
-			;;
-		esac
-	done
-	shift "$((OPTIND - 1))"
+  while getopts ":hi:n:p:r:t:u:" _options; do
+    case "${_options}" in
+    h)
+      usage
+      exit 0
+      ;;
+    i)
+      clamav_docker_image="${OPTARG}"
+      ;;
+    n)
+      clamav_docker_namespace="${OPTARG}"
+      ;;
+    p)
+      clamav_docker_passwd="${OPTARG}"
+      ;;
+    r)
+      docker_registry="${OPTARG}"
+      ;;
+    t)
+      clamav_docker_tag="${OPTARG}"
+      ;;
+    u)
+      clamav_docker_user="${OPTARG}"
+      ;;
+    :)
+      echo >&2 "Option -${OPTARG} requires an argument."
+      exit 1
+      ;;
+    ?)
+      echo >&2 "Invalid option: -${OPTARG}"
+      exit 1
+      ;;
+    esac
+  done
+  shift "$((OPTIND - 1))"
 
-	clamav_docker_namespace="${clamav_docker_namespace:-${CLAMAV_DOCKER_NAMESPACE:-${DEF_CLAMAV_DOCKER_NAMESPACE}}}"
-	clamav_docker_image="${clamav_docker_image:-${CLAMAV_DOCKER_IMAGE:-${DEF_CLAMAV_DOCKER_IMAGE}}}"
-	clamav_docker_passwd="${clamav_docker_passwd:-${DOCKER_PASSWD:-}}"
-	clamav_docker_tag="${clamav_docker_tag:-}"
-	clamav_docker_user="${clamav_docker_user:-${DOCKER_USER:-}}"
-	docker_registry="${docker_registry:-${DOCKER_REGISTRY:-${DEF_DOCKER_REGISTRY}}}"
+  clamav_docker_namespace="${clamav_docker_namespace:-${CLAMAV_DOCKER_NAMESPACE:-${DEF_CLAMAV_DOCKER_NAMESPACE}}}"
+  clamav_docker_image="${clamav_docker_image:-${CLAMAV_DOCKER_IMAGE:-${DEF_CLAMAV_DOCKER_IMAGE}}}"
+  clamav_docker_passwd="${clamav_docker_passwd:-${DOCKER_PASSWD:-}}"
+  clamav_docker_tag="${clamav_docker_tag:-}"
+  clamav_docker_user="${clamav_docker_user:-${DOCKER_USER:-}}"
+  docker_registry="${docker_registry:-${DOCKER_REGISTRY:-${DEF_DOCKER_REGISTRY}}}"
 
-	init
-	config_docker_buildx
+  init
+  config_docker_buildx
 
-	if [ -n "${clamav_docker_tag}" ]; then
-		clamav_docker_tags="${clamav_docker_tag}"
-	else
-		docker_tags_get
-	fi
+  if [ -n "${clamav_docker_tag}" ]; then
+    clamav_docker_tags="${clamav_docker_tag}"
+  else
+    docker_tags_get
+  fi
 
-	clamav_db_update
+  clamav_db_update
 
-	echo "==============================================================================="
-	echo "Build report for $(date -u)"
-	echo
-	echo "Updated database for image tags ..."
-	echo "${clamav_docker_tags:-}"
-	echo
-	echo "... successfully in $(($(date "+%s") - _start_time)) seconds"
-	echo "==============================================================================="
+  echo "==============================================================================="
+  echo "Build report for $(date -u)"
+  echo
+  echo "Updated database for image tags ..."
+  echo "${clamav_docker_tags:-}"
+  echo
+  echo "... successfully in $(($(date "+%s") - _start_time)) seconds"
+  echo "==============================================================================="
 
-	cleanup
+  cleanup
 }
 
 main "${@}"


### PR DESCRIPTION
Fixing tagging for debian multi-arch images.

Dividing Dockerfile RUN commands into sub commands.

Adding readme file changes.

Copying unprivileged init script so that any user can use it by overriding --entrypoint option in docker run.

Resolves: https://github.com/Cisco-Talos/clamav-docker/issues/32
Related to:
- https://github.com/Cisco-Talos/clamav-docker/issues/8
- https://github.com/Cisco-Talos/clamav-docker/issues/30