### PR TITLE
Update debian images from ncurses5 to 6

### DIFF
--- a/clamav/1.0/debian/Dockerfile
+++ b/clamav/1.0/debian/Dockerfile
@@ -30,7 +30,7 @@ RUN apt update && apt install -y \
         libcurl4-openssl-dev \
         libjson-c-dev \
         libmilter-dev \
-        libncurses5-dev \
+        libncurses-dev \
         libpcre2-dev \
         libssl-dev \
         libxml2-dev \
@@ -112,7 +112,7 @@ RUN apt-get update && apt-get install -y \
         libssl1.1 \
         libjson-c5 \
         libmilter1.0.1 \
-        libncurses5 \
+        libncurses6 \
         libpcre2-8-0 \
         libxml2 \
         zlib1g \

--- a/clamav/1.1/debian/Dockerfile
+++ b/clamav/1.1/debian/Dockerfile
@@ -30,7 +30,7 @@ RUN apt update && apt install -y \
         libcurl4-openssl-dev \
         libjson-c-dev \
         libmilter-dev \
-        libncurses5-dev \
+        libncurses-dev \
         libpcre2-dev \
         libssl-dev \
         libxml2-dev \
@@ -112,7 +112,7 @@ RUN apt-get update && apt-get install -y \
         libssl1.1 \
         libjson-c5 \
         libmilter1.0.1 \
-        libncurses5 \
+        libncurses6 \
         libpcre2-8-0 \
         libxml2 \
         zlib1g \

--- a/clamav/1.2/debian/Dockerfile
+++ b/clamav/1.2/debian/Dockerfile
@@ -30,7 +30,7 @@ RUN apt update && apt install -y \
         libcurl4-openssl-dev \
         libjson-c-dev \
         libmilter-dev \
-        libncurses5-dev \
+        libncurses-dev \
         libpcre2-dev \
         libssl-dev \
         libxml2-dev \
@@ -112,7 +112,7 @@ RUN apt-get update && apt-get install -y \
         libssl1.1 \
         libjson-c5 \
         libmilter1.0.1 \
-        libncurses5 \
+        libncurses6 \
         libpcre2-8-0 \
         libxml2 \
         zlib1g \

--- a/clamav/unstable/debian/Dockerfile
+++ b/clamav/unstable/debian/Dockerfile
@@ -30,7 +30,7 @@ RUN apt update && apt install -y \
         libcurl4-openssl-dev \
         libjson-c-dev \
         libmilter-dev \
-        libncurses5-dev \
+        libncurses-dev \
         libpcre2-dev \
         libssl-dev \
         libxml2-dev \
@@ -112,7 +112,7 @@ RUN apt-get update && apt-get install -y \
         libssl1.1 \
         libjson-c5 \
         libmilter1.0.1 \
-        libncurses5 \
+        libncurses6 \
         libpcre2-8-0 \
         libxml2 \
         zlib1g \


### PR DESCRIPTION
The newer ncurses6 is somehow installed during the build phase resulting in a dependency on libncurses6.so instead of libncurses5.so. The solution is to intentionally upgrade from 5 to 6 in both build and final images.

Resolves: https://github.com/Cisco-Talos/clamav/issues/1131