### PR TITLE
Add OCI image annotations, SLSA provenance, and SBOM attestations

### DIFF
--- a/clamav-bytecode-compiler/1.4/ubuntu/Jenkinsfile
+++ b/clamav-bytecode-compiler/1.4/ubuntu/Jenkinsfile
@@ -71,7 +71,7 @@ node('docker') {
 
                 // Build X.Y.Z-R image
                 sh """
-                docker build --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}" .
+                docker build --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}" .
                 """
 
                 // Publish X.Y.Z-R tag

--- a/clamav-bytecode-compiler/1.4/ubuntu/Jenkinsfile
+++ b/clamav-bytecode-compiler/1.4/ubuntu/Jenkinsfile
@@ -71,7 +71,7 @@ node('docker') {
 
                 // Build X.Y.Z-R image
                 sh """
-                docker build --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}" .
+                docker build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}" .
                 """
 
                 // Publish X.Y.Z-R tag

--- a/clamav-bytecode-compiler/1.4/ubuntu/Jenkinsfile
+++ b/clamav-bytecode-compiler/1.4/ubuntu/Jenkinsfile
@@ -71,7 +71,7 @@ node('docker') {
 
                 // Build X.Y.Z-R image
                 sh """
-                docker build --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}" .
+                docker build --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}" .
                 """
 
                 // Publish X.Y.Z-R tag

--- a/clamav-bytecode-compiler/unstable/ubuntu/Jenkinsfile
+++ b/clamav-bytecode-compiler/unstable/ubuntu/Jenkinsfile
@@ -64,7 +64,7 @@ node('docker') {
                 //
 
                 sh """
-                docker build --no-cache --tag "${params.IMAGE_NAME}:unstable" .
+                docker build --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:unstable" .
 
                 # Make a tag with the registry name in it so we can push wherever
                 docker image tag ${params.IMAGE_NAME}:unstable ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable

--- a/clamav-bytecode-compiler/unstable/ubuntu/Jenkinsfile
+++ b/clamav-bytecode-compiler/unstable/ubuntu/Jenkinsfile
@@ -64,7 +64,7 @@ node('docker') {
                 //
 
                 sh """
-                docker build --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:unstable" .
+                docker build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:unstable" .
 
                 # Make a tag with the registry name in it so we can push wherever
                 docker image tag ${params.IMAGE_NAME}:unstable ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable

--- a/clamav-bytecode-compiler/unstable/ubuntu/Jenkinsfile
+++ b/clamav-bytecode-compiler/unstable/ubuntu/Jenkinsfile
@@ -64,7 +64,7 @@ node('docker') {
                 //
 
                 sh """
-                docker build --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:unstable" .
+                docker build --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:unstable" .
 
                 # Make a tag with the registry name in it so we can push wherever
                 docker image tag ${params.IMAGE_NAME}:unstable ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable

--- a/clamav/1.0/alpine/Jenkinsfile
+++ b/clamav/1.0/alpine/Jenkinsfile
@@ -76,7 +76,7 @@ node('docker') {
 
                 // Build X.Y.Z-R_base image.
                 sh """
-                docker build --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
+                docker build --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
                 """
 
                 // Publish X.Y.Z-R_base tag

--- a/clamav/1.0/alpine/Jenkinsfile
+++ b/clamav/1.0/alpine/Jenkinsfile
@@ -76,7 +76,7 @@ node('docker') {
 
                 // Build X.Y.Z-R_base image.
                 sh """
-                docker build --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
+                docker build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
                 """
 
                 // Publish X.Y.Z-R_base tag

--- a/clamav/1.0/alpine/Jenkinsfile
+++ b/clamav/1.0/alpine/Jenkinsfile
@@ -76,7 +76,7 @@ node('docker') {
 
                 // Build X.Y.Z-R_base image.
                 sh """
-                docker build --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
+                docker build --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
                 """
 
                 // Publish X.Y.Z-R_base tag

--- a/clamav/1.0/debian/Jenkinsfile
+++ b/clamav/1.0/debian/Jenkinsfile
@@ -91,6 +91,7 @@ node('macos-newer') {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
                     docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                    --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
@@ -101,6 +102,7 @@ node('macos-newer') {
                 } else {
                      sh """
                         docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                        --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \

--- a/clamav/1.0/debian/Jenkinsfile
+++ b/clamav/1.0/debian/Jenkinsfile
@@ -91,6 +91,7 @@ node('macos-newer') {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
                     docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                    --sbom=true \
                     --provenance mode=max,builder-id="${BUILD_URL}" \
                     --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
@@ -103,6 +104,7 @@ node('macos-newer') {
                 } else {
                      sh """
                         docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                        --sbom=true \
                         --provenance mode=max,builder-id="${BUILD_URL}" \
                         --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \

--- a/clamav/1.0/debian/Jenkinsfile
+++ b/clamav/1.0/debian/Jenkinsfile
@@ -91,6 +91,7 @@ node('macos-newer') {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
                     docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                    --provenance mode=max,builder-id="${BUILD_URL}" \
                     --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
@@ -102,6 +103,7 @@ node('macos-newer') {
                 } else {
                      sh """
                         docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                        --provenance mode=max,builder-id="${BUILD_URL}" \
                         --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \

--- a/clamav/1.2/alpine/Jenkinsfile
+++ b/clamav/1.2/alpine/Jenkinsfile
@@ -76,7 +76,7 @@ node('docker') {
 
                 // Build X.Y.Z-R_base image.
                 sh """
-                docker build --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
+                docker build --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
                 """
 
                 // Publish X.Y.Z-R_base tag

--- a/clamav/1.2/alpine/Jenkinsfile
+++ b/clamav/1.2/alpine/Jenkinsfile
@@ -76,7 +76,7 @@ node('docker') {
 
                 // Build X.Y.Z-R_base image.
                 sh """
-                docker build --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
+                docker build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
                 """
 
                 // Publish X.Y.Z-R_base tag

--- a/clamav/1.2/alpine/Jenkinsfile
+++ b/clamav/1.2/alpine/Jenkinsfile
@@ -76,7 +76,7 @@ node('docker') {
 
                 // Build X.Y.Z-R_base image.
                 sh """
-                docker build --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
+                docker build --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
                 """
 
                 // Publish X.Y.Z-R_base tag

--- a/clamav/1.2/debian/Jenkinsfile
+++ b/clamav/1.2/debian/Jenkinsfile
@@ -91,6 +91,7 @@ node('macos-newer') {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
                     docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                    --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
@@ -101,6 +102,7 @@ node('macos-newer') {
                 } else {
                      sh """
                         docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                        --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \

--- a/clamav/1.2/debian/Jenkinsfile
+++ b/clamav/1.2/debian/Jenkinsfile
@@ -91,6 +91,7 @@ node('macos-newer') {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
                     docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                    --sbom=true \
                     --provenance mode=max,builder-id="${BUILD_URL}" \
                     --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
@@ -103,6 +104,7 @@ node('macos-newer') {
                 } else {
                      sh """
                         docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                        --sbom=true \
                         --provenance mode=max,builder-id="${BUILD_URL}" \
                         --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \

--- a/clamav/1.2/debian/Jenkinsfile
+++ b/clamav/1.2/debian/Jenkinsfile
@@ -91,6 +91,7 @@ node('macos-newer') {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
                     docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                    --provenance mode=max,builder-id="${BUILD_URL}" \
                     --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
@@ -102,6 +103,7 @@ node('macos-newer') {
                 } else {
                      sh """
                         docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                        --provenance mode=max,builder-id="${BUILD_URL}" \
                         --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \

--- a/clamav/1.3/alpine/Jenkinsfile
+++ b/clamav/1.3/alpine/Jenkinsfile
@@ -76,7 +76,7 @@ node('docker') {
 
                 // Build X.Y.Z-R_base image.
                 sh """
-                docker build --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
+                docker build --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
                 """
 
                 // Publish X.Y.Z-R_base tag

--- a/clamav/1.3/alpine/Jenkinsfile
+++ b/clamav/1.3/alpine/Jenkinsfile
@@ -76,7 +76,7 @@ node('docker') {
 
                 // Build X.Y.Z-R_base image.
                 sh """
-                docker build --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
+                docker build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
                 """
 
                 // Publish X.Y.Z-R_base tag

--- a/clamav/1.3/alpine/Jenkinsfile
+++ b/clamav/1.3/alpine/Jenkinsfile
@@ -76,7 +76,7 @@ node('docker') {
 
                 // Build X.Y.Z-R_base image.
                 sh """
-                docker build --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
+                docker build --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
                 """
 
                 // Publish X.Y.Z-R_base tag

--- a/clamav/1.3/debian/Jenkinsfile
+++ b/clamav/1.3/debian/Jenkinsfile
@@ -91,6 +91,7 @@ node('macos-newer') {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
                     docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                    --sbom=true \
                     --provenance mode=max,builder-id="${BUILD_URL}" \
                      --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
@@ -103,6 +104,7 @@ node('macos-newer') {
                 } else {
                      sh """
                         docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                        --sbom=true \
                         --provenance mode=max,builder-id="${BUILD_URL}" \
                         --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \

--- a/clamav/1.3/debian/Jenkinsfile
+++ b/clamav/1.3/debian/Jenkinsfile
@@ -91,6 +91,7 @@ node('macos-newer') {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
                     docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                    --provenance mode=max,builder-id="${BUILD_URL}" \
                      --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
@@ -102,6 +103,7 @@ node('macos-newer') {
                 } else {
                      sh """
                         docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                        --provenance mode=max,builder-id="${BUILD_URL}" \
                         --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \

--- a/clamav/1.3/debian/Jenkinsfile
+++ b/clamav/1.3/debian/Jenkinsfile
@@ -91,6 +91,7 @@ node('macos-newer') {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
                     docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                     --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
@@ -101,6 +102,7 @@ node('macos-newer') {
                 } else {
                      sh """
                         docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                        --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \

--- a/clamav/1.4/alpine/Jenkinsfile
+++ b/clamav/1.4/alpine/Jenkinsfile
@@ -76,7 +76,7 @@ node('docker') {
 
                 // Build X.Y.Z-R_base image.
                 sh """
-                docker build --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
+                docker build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
                 """
 
                 // Publish X.Y.Z-R_base tag

--- a/clamav/1.4/alpine/Jenkinsfile
+++ b/clamav/1.4/alpine/Jenkinsfile
@@ -1,4 +1,4 @@
-properties([
+gproperties([
     parameters([
         string(name: 'DOCKER_REGISTRY', defaultValue: 'registry.hub.docker.com',                    description: 'The Docker registry to use'),
         string(name: 'REGISTRY_CREDS',  defaultValue: 'dockerhub',                                  description: 'The Jenkins credentials ID for the given registry'),
@@ -76,7 +76,7 @@ node('docker') {
 
                 // Build X.Y.Z-R_base image.
                 sh """
-                docker build --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
+                docker build --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
                 """
 
                 // Publish X.Y.Z-R_base tag

--- a/clamav/1.4/alpine/Jenkinsfile
+++ b/clamav/1.4/alpine/Jenkinsfile
@@ -76,7 +76,7 @@ node('docker') {
 
                 // Build X.Y.Z-R_base image.
                 sh """
-                docker build --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
+                docker build --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
                 """
 
                 // Publish X.Y.Z-R_base tag

--- a/clamav/1.4/debian/Jenkinsfile
+++ b/clamav/1.4/debian/Jenkinsfile
@@ -91,6 +91,7 @@ node('macos-newer') {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
                     docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                    --sbom=true \
                     --provenance mode=max,builder-id="${BUILD_URL}" \
                     --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \

--- a/clamav/1.4/debian/Jenkinsfile
+++ b/clamav/1.4/debian/Jenkinsfile
@@ -91,6 +91,7 @@ node('macos-newer') {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
                     docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                    --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \

--- a/clamav/1.4/debian/Jenkinsfile
+++ b/clamav/1.4/debian/Jenkinsfile
@@ -91,6 +91,7 @@ node('macos-newer') {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
                     docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                    --provenance mode=max,builder-id="${BUILD_URL}" \
                     --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \

--- a/clamav/unstable/alpine/Jenkinsfile
+++ b/clamav/unstable/alpine/Jenkinsfile
@@ -64,7 +64,7 @@ node('docker') {
                 //
 
                 sh """
-                docker build --no-cache --tag "${params.IMAGE_NAME}:unstable_base" .
+                docker build --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:unstable_base" .
 
                 # Make a tag with the registry name in it so we can push wherever
                 docker image tag ${params.IMAGE_NAME}:unstable_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base

--- a/clamav/unstable/alpine/Jenkinsfile
+++ b/clamav/unstable/alpine/Jenkinsfile
@@ -64,7 +64,7 @@ node('docker') {
                 //
 
                 sh """
-                docker build --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:unstable_base" .
+                docker build --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:unstable_base" .
 
                 # Make a tag with the registry name in it so we can push wherever
                 docker image tag ${params.IMAGE_NAME}:unstable_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base

--- a/clamav/unstable/alpine/Jenkinsfile
+++ b/clamav/unstable/alpine/Jenkinsfile
@@ -64,7 +64,7 @@ node('docker') {
                 //
 
                 sh """
-                docker build --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:unstable_base" .
+                docker build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.version=${params.FULL_VERSION}" --annotation "org.opencontainers.image.ref.name=${params.BRANCH}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --tag "${params.IMAGE_NAME}:unstable_base" .
 
                 # Make a tag with the registry name in it so we can push wherever
                 docker image tag ${params.IMAGE_NAME}:unstable_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base

--- a/clamav/unstable/debian/Jenkinsfile
+++ b/clamav/unstable/debian/Jenkinsfile
@@ -75,7 +75,7 @@ node('macos-newer') {
 
                 // Build 'unstable' and 'unstable_base' images.
                 sh """
-                docker buildx build  --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base --push .
+                docker buildx build --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base --push .
                 """
 
                 // Give it some time to add the new unstable_base image.

--- a/clamav/unstable/debian/Jenkinsfile
+++ b/clamav/unstable/debian/Jenkinsfile
@@ -75,7 +75,7 @@ node('macos-newer') {
 
                 // Build 'unstable' and 'unstable_base' images.
                 sh """
-                docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base --push .
+                docker buildx build  --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base --push .
                 """
 
                 // Give it some time to add the new unstable_base image.

--- a/clamav/unstable/debian/Jenkinsfile
+++ b/clamav/unstable/debian/Jenkinsfile
@@ -75,7 +75,7 @@ node('macos-newer') {
 
                 // Build 'unstable' and 'unstable_base' images.
                 sh """
-                docker buildx build --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base --push .
+                docker buildx build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" --annotation "org.opencontainers.image.url=${params.REPOSITORY}" --annotation "org.opencontainers.image.source=${params.REPOSITORY}" --annotation "org.opencontainers.image.created=$(date -Iseconds)" --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base --push .
                 """
 
                 // Give it some time to add the new unstable_base image.


### PR DESCRIPTION
Add OCI image annotations to images

> These annotations are useful for people to manual use as well as for use by tools. For example, Snyk uses them in its UI and Renovate uses them to find release notes.
>
> See:
> https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
> * https://snyk.io/blog/how-and-when-to-use-docker-labels-oci-container-annotations/
> * https://github.com/renovatebot/renovate/blob/34.115.1/lib/modules/datasource/docker/readme.md

Attach SLSA provenance attestations to images

> The provenance attestations include facts about the build process, including details such as:
> * Build timestamps
> * Build parameters and environment
> * Version control metadata
> * Source code details
> * Materials (files, scripts) consumed during the build
> 
> See:
> * https://docs.docker.com/build/attestations/slsa-provenance/
> * https://docs.docker.com/build/attestations/slsa-definitions/

Attach SBOM attestations to images

> See: https://docs.docker.com/build/attestations/sbom/
