### PR TITLE
clamav-alpine: 1.3 is no longer latest

### DIFF
--- a/clamav/1.3/alpine/Jenkinsfile
+++ b/clamav/1.3/alpine/Jenkinsfile
@@ -9,7 +9,7 @@ properties([
         string(name: 'BRANCH',          defaultValue: 'rel/1.3',                                    description: 'The repository branch for this build'),
         string(name: 'FULL_VERSION',    defaultValue: '1.3.2',                                      description: 'Full version in X.Y.Z format'),
         string(name: 'FEATURE_VERSION', defaultValue: '1.3',                                        description: 'Feature version in X.Y format'),
-        booleanParam(name: 'IS_LATEST', defaultValue: true,                                         description: 'If "true", will also publish to :latest, and :stable tags.'),
+        booleanParam(name: 'IS_LATEST', defaultValue: false,                                        description: 'If "true", will also publish to :latest, and :stable tags.'),
     ]),
     disableConcurrentBuilds(),
     buildDiscarder(logRotator(


### PR DESCRIPTION
We already changed this for debian.

Alpine was accidentally missed. I ... failed to save the file before commit.