### PR TITLE
Update Docker ENV format

### DIFF
--- a/clamav/1.0/alpine/Dockerfile
+++ b/clamav/1.0/alpine/Dockerfile
@@ -94,7 +94,7 @@ LABEL maintainer="ClamAV bugs <clamav-bugs@external.cisco.com>"
 EXPOSE 3310
 EXPOSE 7357
 
-ENV TZ Etc/UTC
+ENV TZ=Etc/UTC
 
 RUN apk add --no-cache \
         fts \

--- a/clamav/1.0/debian/Dockerfile
+++ b/clamav/1.0/debian/Dockerfile
@@ -9,8 +9,8 @@ WORKDIR /src
 
 COPY . /src/
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV CARGO_HOME /src/build
+ENV DEBIAN_FRONTEND=noninteractive
+ENV CARGO_HOME=/src/build
 
 RUN apt update && apt install -y \
         cmake \
@@ -104,7 +104,7 @@ EXPOSE 3310
 EXPOSE 7357
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV TZ Etc/UTC
+ENV TZ=Etc/UTC
 
 RUN apt-get update && apt-get install -y \
         libbz2-1.0 \

--- a/clamav/1.3/alpine/Dockerfile
+++ b/clamav/1.3/alpine/Dockerfile
@@ -94,7 +94,7 @@ LABEL maintainer="ClamAV bugs <clamav-bugs@external.cisco.com>"
 EXPOSE 3310
 EXPOSE 7357
 
-ENV TZ Etc/UTC
+ENV TZ=Etc/UTC
 
 RUN apk add --no-cache \
         fts \

--- a/clamav/1.3/debian/Dockerfile
+++ b/clamav/1.3/debian/Dockerfile
@@ -9,8 +9,8 @@ WORKDIR /src
 
 COPY . /src/
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV CARGO_HOME /src/build
+ENV DEBIAN_FRONTEND=noninteractive
+ENV CARGO_HOME=/src/build
 
 RUN apt update && apt install -y \
         cmake \
@@ -104,7 +104,7 @@ EXPOSE 3310
 EXPOSE 7357
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV TZ Etc/UTC
+ENV TZ=Etc/UTC
 
 RUN apt-get update && apt-get install -y \
         libbz2-1.0 \

--- a/clamav/1.4/alpine/Dockerfile
+++ b/clamav/1.4/alpine/Dockerfile
@@ -94,7 +94,7 @@ LABEL maintainer="ClamAV bugs <clamav-bugs@external.cisco.com>"
 EXPOSE 3310
 EXPOSE 7357
 
-ENV TZ Etc/UTC
+ENV TZ=Etc/UTC
 
 RUN apk add --no-cache \
         fts \

--- a/clamav/1.4/debian/Dockerfile
+++ b/clamav/1.4/debian/Dockerfile
@@ -9,8 +9,8 @@ WORKDIR /src
 
 COPY . /src/
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV CARGO_HOME /src/build
+ENV DEBIAN_FRONTEND=noninteractive
+ENV CARGO_HOME=/src/build
 
 RUN apt update && apt install -y \
         cmake \
@@ -104,7 +104,7 @@ EXPOSE 3310
 EXPOSE 7357
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV TZ Etc/UTC
+ENV TZ=Etc/UTC
 
 RUN apt-get update && apt-get install -y \
         libbz2-1.0 \

--- a/clamav/unstable/alpine/Dockerfile
+++ b/clamav/unstable/alpine/Dockerfile
@@ -94,7 +94,7 @@ LABEL maintainer="ClamAV bugs <clamav-bugs@external.cisco.com>"
 EXPOSE 3310
 EXPOSE 7357
 
-ENV TZ Etc/UTC
+ENV TZ=Etc/UTC
 
 RUN apk add --no-cache \
         fts \

--- a/clamav/unstable/debian/Dockerfile
+++ b/clamav/unstable/debian/Dockerfile
@@ -9,8 +9,8 @@ WORKDIR /src
 
 COPY . /src/
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV CARGO_HOME /src/build
+ENV DEBIAN_FRONTEND=noninteractive
+ENV CARGO_HOME=/src/build
 
 RUN apt update && apt install -y \
         cmake \
@@ -104,7 +104,7 @@ EXPOSE 3310
 EXPOSE 7357
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV TZ Etc/UTC
+ENV TZ=Etc/UTC
 
 RUN apt-get update && apt-get install -y \
         libbz2-1.0 \


### PR DESCRIPTION
Fix warnings:
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 12)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 13)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 107)

Ref: https://docs.docker.com/reference/build-checks/legacy-key-value-format/