### PR TITLE
Add config values using env vars

### DIFF
--- a/clamav/1.0/alpine/scripts/docker-entrypoint.sh
+++ b/clamav/1.0/alpine/scripts/docker-entrypoint.sh
@@ -17,6 +17,23 @@ fi
 # Assign ownership to the database directory, just in case it is a mounted volume
 chown -R clamav:clamav /var/lib/clamav
 
+# configure freshclam.conf and clamd.conf from env variables if present
+env | grep "^CLAMD_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#CLAMD_CONF_}"
+
+    grep -q "^$TRIMMED " /etc/clamav/clamd.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/clamd.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/clamd.conf
+done
+
+env | grep "^FRESHCLAM_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#FRESHCLAM_CONF_}"
+
+    grep -q "^$TRIMMED " /etc/clamav/freshclam.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/freshclam.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/freshclam.conf
+done
+
 # run command if it is not starting with a "-" and is an executable in PATH
 if [ "${#}" -gt 0 ] && \
    [ "${1#-}" = "${1}" ] && \

--- a/clamav/1.0/debian/scripts/docker-entrypoint.sh
+++ b/clamav/1.0/debian/scripts/docker-entrypoint.sh
@@ -17,6 +17,23 @@ fi
 # Assign ownership to the database directory, just in case it is a mounted volume
 chown -R clamav:clamav /var/lib/clamav
 
+# configure freshclam.conf and clamd.conf from env variables if present
+env | grep "^CLAMD_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#CLAMD_CONF_}"
+
+    grep -q "^$TRIMMED " /etc/clamav/clamd.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/clamd.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/clamd.conf
+done
+
+env | grep "^FRESHCLAM_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#FRESHCLAM_CONF_}"
+
+    grep -q "^$TRIMMED " /etc/clamav/freshclam.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/freshclam.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/freshclam.conf
+done
+
 # run command if it is not starting with a "-" and is an executable in PATH
 if [ "${#}" -gt 0 ] && \
    [ "${1#-}" = "${1}" ] && \

--- a/clamav/1.3/alpine/scripts/docker-entrypoint.sh
+++ b/clamav/1.3/alpine/scripts/docker-entrypoint.sh
@@ -17,6 +17,23 @@ fi
 # Assign ownership to the database directory, just in case it is a mounted volume
 chown -R clamav:clamav /var/lib/clamav
 
+# configure freshclam.conf and clamd.conf from env variables if present
+env | grep "^CLAMD_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#CLAMD_CONF_}"
+
+    grep -q "^$TRIMMED " /etc/clamav/clamd.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/clamd.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/clamd.conf
+done
+
+env | grep "^FRESHCLAM_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#FRESHCLAM_CONF_}"
+
+    grep -q "^$TRIMMED " /etc/clamav/freshclam.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/freshclam.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/freshclam.conf
+done
+
 # run command if it is not starting with a "-" and is an executable in PATH
 if [ "${#}" -gt 0 ] && \
    [ "${1#-}" = "${1}" ] && \

--- a/clamav/1.3/debian/scripts/docker-entrypoint.sh
+++ b/clamav/1.3/debian/scripts/docker-entrypoint.sh
@@ -17,6 +17,23 @@ fi
 # Assign ownership to the database directory, just in case it is a mounted volume
 chown -R clamav:clamav /var/lib/clamav
 
+# configure freshclam.conf and clamd.conf from env variables if present
+env | grep "^CLAMD_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#CLAMD_CONF_}"
+
+    grep -q "^$TRIMMED " /etc/clamav/clamd.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/clamd.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/clamd.conf
+done
+
+env | grep "^FRESHCLAM_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#FRESHCLAM_CONF_}"
+
+    grep -q "^$TRIMMED " /etc/clamav/freshclam.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/freshclam.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/freshclam.conf
+done
+
 # run command if it is not starting with a "-" and is an executable in PATH
 if [ "${#}" -gt 0 ] && \
    [ "${1#-}" = "${1}" ] && \

--- a/clamav/1.4/alpine/scripts/docker-entrypoint.sh
+++ b/clamav/1.4/alpine/scripts/docker-entrypoint.sh
@@ -17,6 +17,40 @@ fi
 # Assign ownership to the database directory, just in case it is a mounted volume
 chown -R clamav:clamav /var/lib/clamav
 
+# configure freshclam.conf and clamd.conf from env variables if present
+env | grep "^CLAMD_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#CLAMD_CONF_}"
+
+    grep -q "^$TRIMMED " /etc/clamav/clamd.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/clamd.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/clamd.conf
+done
+
+env | grep "^FRESHCLAM_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#FRESHCLAM_CONF_}"
+
+    grep -q "^$TRIMMED " /etc/clamav/freshclam.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/freshclam.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/freshclam.conf
+done
+
+# configure freshclam.conf and clamd.conf from env variables if present
+env | grep "^CLAMD_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#CLAMD_CONF_}"
+
+    grep -q "^$TRIMMED " /etc/clamav/clamd.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/clamd.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/clamd.conf
+done
+
+env | grep "^FRESHCLAM_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#FRESHCLAM_CONF_}"
+
+    grep -q "^$TRIMMED " /etc/clamav/freshclam.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/freshclam.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/freshclam.conf
+done
+
 # run command if it is not starting with a "-" and is an executable in PATH
 if [ "${#}" -gt 0 ] && \
    [ "${1#-}" = "${1}" ] && \

--- a/clamav/1.4/debian/scripts/docker-entrypoint.sh
+++ b/clamav/1.4/debian/scripts/docker-entrypoint.sh
@@ -17,6 +17,40 @@ fi
 # Assign ownership to the database directory, just in case it is a mounted volume
 chown -R clamav:clamav /var/lib/clamav
 
+# configure freshclam.conf and clamd.conf from env variables if present
+env | grep "^CLAMD_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#CLAMD_CONF_}"
+
+    grep -q "^$TRIMMED " /etc/clamav/clamd.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/clamd.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/clamd.conf
+done
+
+env | grep "^FRESHCLAM_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#FRESHCLAM_CONF_}"
+
+    grep -q "^$TRIMMED " /etc/clamav/freshclam.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/freshclam.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/freshclam.conf
+done
+
+# configure freshclam.conf and clamd.conf from env variables if present
+env | grep "^CLAMD_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#CLAMD_CONF_}"
+    
+    grep -q "^$TRIMMED " /etc/clamav/clamd.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/clamd.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/clamd.conf
+done
+
+env | grep "^FRESHCLAM_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#FRESHCLAM_CONF_}"
+
+    grep -q "^$TRIMMED " /etc/clamav/freshclam.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/freshclam.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/freshclam.conf
+done
+
 # run command if it is not starting with a "-" and is an executable in PATH
 if [ "${#}" -gt 0 ] && \
    [ "${1#-}" = "${1}" ] && \

--- a/clamav/README-alpine.md
+++ b/clamav/README-alpine.md
@@ -333,7 +333,7 @@ added:
     --env 'CLAMAV_NO_MILTERD=false'
 ```
 
-Further more, all of the configuration files that live in `/etc/clamav` can be
+Furthermore, all the configuration files that live in `/etc/clamav` can be
 overridden by doing a volume-mount to the specific file. The following argument
 can be added for this purpose. The example uses the entire configuration
 directory, but this can be supplied multiple times if individual files deem to
@@ -347,6 +347,39 @@ run at least once during container startup if there is no virus database.
 While not recommended, the virus database location itself `/var/lib/clamav/`
 could be a persistent Docker volume. This however is slightly more advanced
 and out of scope of this document.
+
+### Automatically apply environment variables to configurations
+
+You can configure both ClamAV and FreshClam dynamically by passing environment variables with specific prefixes when running the container. These variables will be automatically applied to the corresponding configuration files (`/etc/clamav/clamd.conf` for ClamAV and `/etc/clamav/freshclam.conf` for FreshClam).
+
+#### Usage Example
+
+To update ClamAV and FreshClam configurations using environment variables, run the container with the `-e` flag:
+
+```bash
+docker run --rm -e CLAMD_CONF_LogTime=no -e CLAMD_CONF_MaxThreads=5 -e FRESHCLAM_CONF_Checks=24 your-clamav-image
+```
+
+This will result in:
+- `/etc/clamav/clamd.conf`:
+```
+LogTime no
+MaxThreads 5
+```
+- `/etc/clamav/freshclam.conf`:
+```
+Checks 24
+```
+
+How It Works
+
+- **Prefix**: Use `CLAMD_CONF_` for ClamAV settings and `FRESHCLAM_CONF_` for FreshClam settings.
+- **Key/Value Mapping**: The part after the prefix is the configuration key, and the environment variable's value is applied in the respective config file.
+
+For example, `CLAMD_CONF_LogTime=no` becomes `LogTime no` in `clamd.conf`, and `FRESHCLAM_CONF_Checks=24` becomes `Checks 24` in `freshclam.conf`.
+
+The script processes these variables on container startup, replacing existing keys or appending new ones as needed.
+
 
 ## Connecting to the container
 
@@ -442,7 +475,7 @@ the various systems somewhat.
 
 Of course, nothing in life is free, and so there is some overhead. Disk-space
 being the most prominent one. The Docker container might have some duplication
-of files for example between the host and the container. Further more, also RAM
+of files for example between the host and the container. Furthermore, also RAM
 memory may be duplicated for each instance, as there is no RAM-deduplication.
 Both of which can be solved on the host however. A filesystem that supports
 disk-deduplication and a memory manager that does RAM-deduplication.

--- a/clamav/README-debian.md
+++ b/clamav/README-debian.md
@@ -343,7 +343,7 @@ added:
     --env 'CLAMAV_NO_MILTERD=false'
 ```
 
-Further more, all of the configuration files that live in `/etc/clamav` can be
+Furthermore, all the configuration files that live in `/etc/clamav` can be
 overridden by doing a volume-mount to the specific file. The following argument
 can be added for this purpose. The example uses the entire configuration
 directory, but this can be supplied multiple times if individual files deem to
@@ -357,6 +357,39 @@ run at least once during container startup if there is no virus database.
 While not recommended, the virus database location itself `/var/lib/clamav/`
 could be a persistent Docker volume. This however is slightly more advanced
 and out of scope of this document.
+
+### Automatically apply environment variables to configurations
+
+You can configure both ClamAV and FreshClam dynamically by passing environment variables with specific prefixes when running the container. These variables will be automatically applied to the corresponding configuration files (`/etc/clamav/clamd.conf` for ClamAV and `/etc/clamav/freshclam.conf` for FreshClam).
+
+#### Usage Example
+
+To update ClamAV and FreshClam configurations using environment variables, run the container with the `-e` flag:
+
+```bash
+docker run --rm -e CLAMD_CONF_LogTime=no -e CLAMD_CONF_MaxThreads=5 -e FRESHCLAM_CONF_Checks=24 your-clamav-image
+```
+
+This will result in:
+- `/etc/clamav/clamd.conf`:
+```
+LogTime no
+MaxThreads 5
+```
+- `/etc/clamav/freshclam.conf`:
+```
+Checks 24
+```
+
+How It Works
+
+- **Prefix**: Use `CLAMD_CONF_` for ClamAV settings and `FRESHCLAM_CONF_` for FreshClam settings.
+- **Key/Value Mapping**: The part after the prefix is the configuration key, and the environment variable's value is applied in the respective config file.
+
+For example, `CLAMD_CONF_LogTime=no` becomes `LogTime no` in `clamd.conf`, and `FRESHCLAM_CONF_Checks=24` becomes `Checks 24` in `freshclam.conf`.
+
+The script processes these variables on container startup, replacing existing keys or appending new ones as needed.
+
 
 ## Connecting to the container
 
@@ -452,7 +485,7 @@ the various systems somewhat.
 
 Of course, nothing in life is free, and so there is some overhead. Disk-space
 being the most prominent one. The Docker container might have some duplication
-of files for example between the host and the container. Further more, also RAM
+of files for example between the host and the container. Furthermore, also RAM
 memory may be duplicated for each instance, as there is no RAM-deduplication.
 Both of which can be solved on the host however. A filesystem that supports
 disk-deduplication and a memory manager that does RAM-deduplication.

--- a/clamav/unstable/alpine/scripts/docker-entrypoint.sh
+++ b/clamav/unstable/alpine/scripts/docker-entrypoint.sh
@@ -17,6 +17,23 @@ fi
 # Assign ownership to the database directory, just in case it is a mounted volume
 chown -R clamav:clamav /var/lib/clamav
 
+# configure freshclam.conf and clamd.conf from env variables if present
+env | grep "^CLAMD_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#CLAMD_CONF_}"
+
+    grep -q "^$TRIMMED " /etc/clamav/clamd.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/clamd.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/clamd.conf
+done
+
+env | grep "^FRESHCLAM_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#FRESHCLAM_CONF_}"
+
+    grep -q "^$TRIMMED " /etc/clamav/freshclam.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/freshclam.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/freshclam.conf
+done
+
 # run command if it is not starting with a "-" and is an executable in PATH
 if [ "${#}" -gt 0 ] && \
    [ "${1#-}" = "${1}" ] && \

--- a/clamav/unstable/debian/scripts/docker-entrypoint.sh
+++ b/clamav/unstable/debian/scripts/docker-entrypoint.sh
@@ -17,6 +17,23 @@ fi
 # Assign ownership to the database directory, just in case it is a mounted volume
 chown -R clamav:clamav /var/lib/clamav
 
+# configure freshclam.conf and clamd.conf from env variables if present
+env | grep "^CLAMD_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#CLAMD_CONF_}"
+
+    grep -q "^$TRIMMED " /etc/clamav/clamd.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/clamd.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/clamd.conf
+done
+
+env | grep "^FRESHCLAM_CONF_" | while IFS="=" read -r KEY VALUE; do
+    TRIMMED="${KEY#FRESHCLAM_CONF_}"
+
+    grep -q "^$TRIMMED " /etc/clamav/freshclam.conf && \
+        sed -i "s/^$TRIMMED .*/$TRIMMED $VALUE/" /etc/clamav/freshclam.conf || \
+        sed -i "\$ a\\$TRIMMED $VALUE" /etc/clamav/freshclam.conf
+done
+
 # run command if it is not starting with a "-" and is an executable in PATH
 if [ "${#}" -gt 0 ] && \
    [ "${1#-}" = "${1}" ] && \


### PR DESCRIPTION
supply configuration values using -e like `-e CLAMD_CONF_StreamMaxLength=3000M` to add/replace them in the config for clamd or `FRESHCLAM_CONF_xxx` respectably for freshclam

inspired by https://github.com/mko-x/docker-clamav/blob/136fd83e5a7bad2e63fc87497be45d11eb838e94/debian/buster/envconfig.sh#L17-L23

unfortunately only possible in privileged mode as one can and should not modify the configs as clamd user

fixes gh-27