### PR TITLE
Adding annotations, Provenance and SBOM to docker images

### DIFF
--- a/clamav-bytecode-compiler/1.4/ubuntu/Jenkinsfile
+++ b/clamav-bytecode-compiler/1.4/ubuntu/Jenkinsfile
@@ -69,37 +69,35 @@ node('docker') {
                 // And maybe also the 'latest' and 'stable' images.
                 //
 
-                // Build X.Y.Z-R image
-                sh """
-                docker build --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}" .
-                """
-
-                // Publish X.Y.Z-R tag
-                sh """
-                docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}
-                """
-
-                // Publish X.Y.Z tag
-                sh """
-                docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}
-                """
-
-                // Publish X.Y tag
-                sh """
-                docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
-                """
-
                 if (params.IS_LATEST) {
-                    // Create & Publish 'stable' and 'latest' tags.
+                    // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
-                    docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable
-
-                    docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
+                    docker build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                                 --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                                 --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                                 --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                                 --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                                 --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest \
+                                 --no-cache --push .
+                    """
+                }
+                else {
+                    sh """
+                    docker build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                                 --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                                 --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                                 --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                                 --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                                 --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
+                                 --no-cache --push .
                     """
                 }
 

--- a/clamav-bytecode-compiler/1.4/ubuntu/Jenkinsfile
+++ b/clamav-bytecode-compiler/1.4/ubuntu/Jenkinsfile
@@ -72,7 +72,7 @@ node('docker') {
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
-                    docker build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                    docker buildx build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
                                  --annotation org.opencontainers.image.url=${params.REPOSITORY} \
                                  --annotation org.opencontainers.image.source=${params.REPOSITORY} \
                                  --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
@@ -88,7 +88,7 @@ node('docker') {
                 }
                 else {
                     sh """
-                    docker build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                    docker buildx build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
                                  --annotation org.opencontainers.image.url=${params.REPOSITORY} \
                                  --annotation org.opencontainers.image.source=${params.REPOSITORY} \
                                  --annotation org.opencontainers.image.version=${params.FULL_VERSION} \

--- a/clamav-bytecode-compiler/unstable/ubuntu/Jenkinsfile
+++ b/clamav-bytecode-compiler/unstable/ubuntu/Jenkinsfile
@@ -67,8 +67,6 @@ node('docker') {
                 docker build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
                              --annotation org.opencontainers.image.url=${params.REPOSITORY} \
                              --annotation org.opencontainers.image.source=${params.REPOSITORY} \
-                             --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
-                             --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
                              --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
                              --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable \
                              --no-cache --push .

--- a/clamav-bytecode-compiler/unstable/ubuntu/Jenkinsfile
+++ b/clamav-bytecode-compiler/unstable/ubuntu/Jenkinsfile
@@ -64,13 +64,14 @@ node('docker') {
                 //
 
                 sh """
-                docker build --no-cache --tag "${params.IMAGE_NAME}:unstable" .
-
-                # Make a tag with the registry name in it so we can push wherever
-                docker image tag ${params.IMAGE_NAME}:unstable ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable
-
-                # Push the image/tag
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable
+                docker build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                             --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                             --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                             --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                             --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                             --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable \
+                             --no-cache --push .
                 """
 
                 // log-out

--- a/clamav-bytecode-compiler/unstable/ubuntu/Jenkinsfile
+++ b/clamav-bytecode-compiler/unstable/ubuntu/Jenkinsfile
@@ -64,7 +64,7 @@ node('docker') {
                 //
 
                 sh """
-                docker build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                docker buildx build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
                              --annotation org.opencontainers.image.url=${params.REPOSITORY} \
                              --annotation org.opencontainers.image.source=${params.REPOSITORY} \
                              --annotation org.opencontainers.image.created="\$(date -Iseconds)" \

--- a/clamav/1.0/alpine/Jenkinsfile
+++ b/clamav/1.0/alpine/Jenkinsfile
@@ -75,36 +75,36 @@ node('docker') {
                 //
 
                 // Build X.Y.Z-R_base image.
-                sh """
-                docker build --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
-                """
-
-                // Publish X.Y.Z-R_base tag
-                sh """
-                docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base
-                """
-
-                // Publish X.Y.Z_base tag
-                sh """
-                docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base
-                """
-
-                // Publish X.Y_base tag
-                sh """
-                docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base
-                """
 
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
-                    docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base
-
-                    docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base
+                    docker build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                                 --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                                 --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                                 --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                                 --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                                 --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
+                                 --no-cache --push .
+                    """
+                }
+                else {
+                    sh """
+                    docker build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                                 --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                                 --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                                 --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                                 --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                                 --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                                 --no-cache --push .
                     """
                 }
 
@@ -128,25 +128,22 @@ node('docker') {
                 """
 
                 // Publish X.Y.Z tag (without the _base suffix)
-                sh """
-                docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}
-                """
-
-                // Publish X.Y tag (without the _base suffix)
-                sh """
-                docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
-                """
 
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable' and 'latest' tags.
                     sh """
-                    docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable
-
-                    docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
+                        docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
+                    """
+                }
+                else {
+                    sh """
+                        docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
                     """
                 }
 

--- a/clamav/1.0/alpine/Jenkinsfile
+++ b/clamav/1.0/alpine/Jenkinsfile
@@ -79,7 +79,7 @@ node('docker') {
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
-                    docker build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                    docker buildx build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
                                  --annotation org.opencontainers.image.url=${params.REPOSITORY} \
                                  --annotation org.opencontainers.image.source=${params.REPOSITORY} \
                                  --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
@@ -95,7 +95,7 @@ node('docker') {
                 }
                 else {
                     sh """
-                    docker build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                    docker buildx build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
                                  --annotation org.opencontainers.image.url=${params.REPOSITORY} \
                                  --annotation org.opencontainers.image.source=${params.REPOSITORY} \
                                  --annotation org.opencontainers.image.version=${params.FULL_VERSION} \

--- a/clamav/1.0/alpine/scripts/update_db_image.sh
+++ b/clamav/1.0/alpine/scripts/update_db_image.sh
@@ -92,9 +92,13 @@ clamav_db_update()
 			echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
 		} | \
 		# Pull and Build the updated image with the tag without the _base suffix.
-		docker image build --pull --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" -
-		# Push the updated image with the tag without the _base suffix.
-		docker image push "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}"
+    docker build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+       --annotation "org.opencontainers.image.url=${REPOSITORY}" \
+       --annotation "org.opencontainers.image.source=${REPOSITORY}" \
+       --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
+       --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
+       --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
+       --pull --push --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" -
 	done
 }
 

--- a/clamav/1.0/alpine/scripts/update_db_image.sh
+++ b/clamav/1.0/alpine/scripts/update_db_image.sh
@@ -92,7 +92,7 @@ clamav_db_update()
 			echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
 		} | \
 		# Pull and Build the updated image with the tag without the _base suffix.
-    docker build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+    docker buildx build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
        --annotation "org.opencontainers.image.url=${REPOSITORY}" \
        --annotation "org.opencontainers.image.source=${REPOSITORY}" \
        --annotation "org.opencontainers.image.version=${FULL_VERSION}" \

--- a/clamav/1.0/debian/Jenkinsfile
+++ b/clamav/1.0/debian/Jenkinsfile
@@ -87,25 +87,40 @@ node('macos-newer') {
                 //  - stable,   stable_base
                 //
 
+                // Build X.Y.Z-R_base image.
+
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
-                    docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
-                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
-                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
-                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
-                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
-                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
-                    --push .
-                    """
-                } else {
-                     sh """
                         docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
-                        --push .
-                     """
+                            --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                            --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                            --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                            --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                            --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                            --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
+                            --push .
+                    """
+                }
+                else {
+                    sh """
+                        docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                            --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                            --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                            --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                            --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                            --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                            --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                            --push .
+                    """
                 }
 
                 // The update_db_image.sh script will query for tags during the update process.
@@ -138,14 +153,13 @@ node('macos-newer') {
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
                     """
-                } else {
+                }
+                else {
                     sh """
                         docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
-
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
                     """
-
                 }
 
                 // log-out (again)

--- a/clamav/1.0/debian/scripts/update_db_image.sh
+++ b/clamav/1.0/debian/scripts/update_db_image.sh
@@ -90,8 +90,13 @@ clamav_db_update() {
       # Update the database
       echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
     } | \
-      docker buildx build --platform linux/amd64 --pull --rm --push \
-        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
+      docker buildx build --platform linux/amd64 --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+        --annotation "org.opencontainers.image.url=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.source=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
+        --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
+        --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
+        --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
 
     {
       # Starting with the image tag with the _base suffix
@@ -99,8 +104,13 @@ clamav_db_update() {
       # Update the database
       echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
     } | \
-      docker buildx build --platform linux/arm64 --pull --rm --push \
-        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
+      docker buildx build --platform linux/arm64 --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+        --annotation "org.opencontainers.image.url=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.source=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
+        --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
+        --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
+        --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
 
     {
       # Starting with the image tag with the _base suffix
@@ -108,9 +118,13 @@ clamav_db_update() {
       # Update the database
       echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
     } | \
-      docker buildx build --platform linux/ppc64le --pull --rm --push \
-        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
-
+      docker buildx build --platform linux/ppc64le --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+        --annotation "org.opencontainers.image.url=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.source=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
+        --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
+        --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
+        --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
   done
 
   docker buildx imagetools create -t "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \

--- a/clamav/1.3/alpine/Jenkinsfile
+++ b/clamav/1.3/alpine/Jenkinsfile
@@ -75,36 +75,36 @@ node('docker') {
                 //
 
                 // Build X.Y.Z-R_base image.
-                sh """
-                docker build --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
-                """
-
-                // Publish X.Y.Z-R_base tag
-                sh """
-                docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base
-                """
-
-                // Publish X.Y.Z_base tag
-                sh """
-                docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base
-                """
-
-                // Publish X.Y_base tag
-                sh """
-                docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base
-                """
 
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
-                    docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base
-
-                    docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base
+                    docker build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                                 --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                                 --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                                 --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                                 --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                                 --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
+                                 --no-cache --push .
+                    """
+                }
+                else {
+                    sh """
+                    docker build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                                 --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                                 --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                                 --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                                 --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                                 --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                                 --no-cache --push .
                     """
                 }
 
@@ -128,25 +128,22 @@ node('docker') {
                 """
 
                 // Publish X.Y.Z tag (without the _base suffix)
-                sh """
-                docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}
-                """
-
-                // Publish X.Y tag (without the _base suffix)
-                sh """
-                docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
-                """
 
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable' and 'latest' tags.
                     sh """
-                    docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable
-
-                    docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
+                        docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
+                    """
+                }
+                else {
+                    sh """
+                        docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
                     """
                 }
 

--- a/clamav/1.3/alpine/Jenkinsfile
+++ b/clamav/1.3/alpine/Jenkinsfile
@@ -79,7 +79,7 @@ node('docker') {
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
-                    docker build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                    docker buildx build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
                                  --annotation org.opencontainers.image.url=${params.REPOSITORY} \
                                  --annotation org.opencontainers.image.source=${params.REPOSITORY} \
                                  --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
@@ -95,7 +95,7 @@ node('docker') {
                 }
                 else {
                     sh """
-                    docker build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                    docker buildx build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
                                  --annotation org.opencontainers.image.url=${params.REPOSITORY} \
                                  --annotation org.opencontainers.image.source=${params.REPOSITORY} \
                                  --annotation org.opencontainers.image.version=${params.FULL_VERSION} \

--- a/clamav/1.3/alpine/scripts/update_db_image.sh
+++ b/clamav/1.3/alpine/scripts/update_db_image.sh
@@ -92,9 +92,13 @@ clamav_db_update()
 			echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
 		} | \
 		# Pull and Build the updated image with the tag without the _base suffix.
-		docker image build --pull --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" -
-		# Push the updated image with the tag without the _base suffix.
-		docker image push "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}"
+    docker build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+       --annotation "org.opencontainers.image.url=${REPOSITORY}" \
+       --annotation "org.opencontainers.image.source=${REPOSITORY}" \
+       --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
+       --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
+       --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
+       --pull --push --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" -
 	done
 }
 

--- a/clamav/1.3/alpine/scripts/update_db_image.sh
+++ b/clamav/1.3/alpine/scripts/update_db_image.sh
@@ -92,7 +92,7 @@ clamav_db_update()
 			echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
 		} | \
 		# Pull and Build the updated image with the tag without the _base suffix.
-    docker build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+    docker buildx build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
        --annotation "org.opencontainers.image.url=${REPOSITORY}" \
        --annotation "org.opencontainers.image.source=${REPOSITORY}" \
        --annotation "org.opencontainers.image.version=${FULL_VERSION}" \

--- a/clamav/1.3/debian/Jenkinsfile
+++ b/clamav/1.3/debian/Jenkinsfile
@@ -87,25 +87,40 @@ node('macos-newer') {
                 //  - stable,   stable_base
                 //
 
+                // Build X.Y.Z-R_base image.
+
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
-                    docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
-                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
-                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
-                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
-                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
-                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
-                    --push .
-                    """
-                } else {
-                     sh """
                         docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
-                        --push .
-                     """
+                            --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                            --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                            --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                            --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                            --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                            --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
+                            --push .
+                    """
+                }
+                else {
+                    sh """
+                        docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                            --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                            --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                            --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                            --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                            --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                            --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                            --push .
+                    """
                 }
 
                 // The update_db_image.sh script will query for tags during the update process.
@@ -138,14 +153,13 @@ node('macos-newer') {
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
                     """
-                } else {
+                }
+                else {
                     sh """
                         docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
-
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
                     """
-
                 }
 
                 // log-out (again)

--- a/clamav/1.3/debian/scripts/update_db_image.sh
+++ b/clamav/1.3/debian/scripts/update_db_image.sh
@@ -90,8 +90,13 @@ clamav_db_update() {
       # Update the database
       echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
     } | \
-      docker buildx build --platform linux/amd64 --pull --rm --push \
-        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
+      docker buildx build --platform linux/amd64 --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+        --annotation "org.opencontainers.image.url=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.source=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
+        --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
+        --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
+        --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
 
     {
       # Starting with the image tag with the _base suffix
@@ -99,8 +104,13 @@ clamav_db_update() {
       # Update the database
       echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
     } | \
-      docker buildx build --platform linux/arm64 --pull --rm --push \
-        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
+      docker buildx build --platform linux/arm64 --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+        --annotation "org.opencontainers.image.url=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.source=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
+        --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
+        --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
+        --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
 
     {
       # Starting with the image tag with the _base suffix
@@ -108,9 +118,13 @@ clamav_db_update() {
       # Update the database
       echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
     } | \
-      docker buildx build --platform linux/ppc64le --pull --rm --push \
-        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
-
+      docker buildx build --platform linux/ppc64le --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+        --annotation "org.opencontainers.image.url=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.source=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
+        --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
+        --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
+        --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
   done
 
   docker buildx imagetools create -t "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \

--- a/clamav/1.4/alpine/Jenkinsfile
+++ b/clamav/1.4/alpine/Jenkinsfile
@@ -75,36 +75,36 @@ node('docker') {
                 //
 
                 // Build X.Y.Z-R_base image.
-                sh """
-                docker build --no-cache --tag "${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base" .
-                """
-
-                // Publish X.Y.Z-R_base tag
-                sh """
-                docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base
-                """
-
-                // Publish X.Y.Z_base tag
-                sh """
-                docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base
-                """
-
-                // Publish X.Y_base tag
-                sh """
-                docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base
-                """
 
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
-                    docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base
-
-                    docker image tag ${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base
+                    docker build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                                 --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                                 --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                                 --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                                 --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                                 --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
+                                 --no-cache --push .
+                    """
+                }
+                else {
+                    sh """
+                    docker build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                                 --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                                 --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                                 --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                                 --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                                 --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
+                                 --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                                 --no-cache --push .
                     """
                 }
 
@@ -128,25 +128,22 @@ node('docker') {
                 """
 
                 // Publish X.Y.Z tag (without the _base suffix)
-                sh """
-                docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}
-                """
-
-                // Publish X.Y tag (without the _base suffix)
-                sh """
-                docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
-                """
 
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable' and 'latest' tags.
                     sh """
-                    docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable
-
-                    docker image tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
-                    docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
+                        docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
+                    """
+                }
+                else {
+                    sh """
+                        docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
                     """
                 }
 

--- a/clamav/1.4/alpine/Jenkinsfile
+++ b/clamav/1.4/alpine/Jenkinsfile
@@ -79,7 +79,7 @@ node('docker') {
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
-                    docker build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                    docker buildx build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
                                  --annotation org.opencontainers.image.url=${params.REPOSITORY} \
                                  --annotation org.opencontainers.image.source=${params.REPOSITORY} \
                                  --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
@@ -95,7 +95,7 @@ node('docker') {
                 }
                 else {
                     sh """
-                    docker build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                    docker buildx build --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
                                  --annotation org.opencontainers.image.url=${params.REPOSITORY} \
                                  --annotation org.opencontainers.image.source=${params.REPOSITORY} \
                                  --annotation org.opencontainers.image.version=${params.FULL_VERSION} \

--- a/clamav/1.4/alpine/scripts/update_db_image.sh
+++ b/clamav/1.4/alpine/scripts/update_db_image.sh
@@ -92,9 +92,13 @@ clamav_db_update()
 			echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
 		} | \
 		# Pull and Build the updated image with the tag without the _base suffix.
-		docker image build --pull --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" -
-		# Push the updated image with the tag without the _base suffix.
-		docker image push "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}"
+    docker build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+       --annotation "org.opencontainers.image.url=${REPOSITORY}" \
+       --annotation "org.opencontainers.image.source=${REPOSITORY}" \
+       --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
+       --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
+       --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
+       --pull --push --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" -
 	done
 }
 

--- a/clamav/1.4/alpine/scripts/update_db_image.sh
+++ b/clamav/1.4/alpine/scripts/update_db_image.sh
@@ -92,7 +92,7 @@ clamav_db_update()
 			echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
 		} | \
 		# Pull and Build the updated image with the tag without the _base suffix.
-    docker build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+    docker buildx build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
        --annotation "org.opencontainers.image.url=${REPOSITORY}" \
        --annotation "org.opencontainers.image.source=${REPOSITORY}" \
        --annotation "org.opencontainers.image.version=${FULL_VERSION}" \

--- a/clamav/1.4/debian/Jenkinsfile
+++ b/clamav/1.4/debian/Jenkinsfile
@@ -87,25 +87,40 @@ node('macos-newer') {
                 //  - stable,   stable_base
                 //
 
+                // Build X.Y.Z-R_base image.
+
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
-                    docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
-                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
-                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
-                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
-                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
-                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
-                    --push .
-                    """
-                } else {
-                     sh """
                         docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
-                        --push .
-                     """
+                            --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                            --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                            --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                            --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                            --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                            --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
+                            --push .
+                    """
+                }
+                else {
+                    sh """
+                        docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                            --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                            --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                            --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                            --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                            --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                            --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                            --push .
+                    """
                 }
 
                 // The update_db_image.sh script will query for tags during the update process.
@@ -138,14 +153,13 @@ node('macos-newer') {
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
                     """
-                } else {
+                }
+                else {
                     sh """
                         docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER} \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
-
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}
                     """
-
                 }
 
                 // log-out (again)

--- a/clamav/1.4/debian/scripts/update_db_image.sh
+++ b/clamav/1.4/debian/scripts/update_db_image.sh
@@ -90,8 +90,13 @@ clamav_db_update() {
       # Update the database
       echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
     } | \
-      docker buildx build --platform linux/amd64 --pull --rm --push \
-        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
+      docker buildx build --platform linux/amd64 --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+        --annotation "org.opencontainers.image.url=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.source=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
+        --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
+        --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
+        --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
 
     {
       # Starting with the image tag with the _base suffix
@@ -99,8 +104,13 @@ clamav_db_update() {
       # Update the database
       echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
     } | \
-      docker buildx build --platform linux/arm64 --pull --rm --push \
-        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
+      docker buildx build --platform linux/arm64 --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+        --annotation "org.opencontainers.image.url=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.source=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
+        --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
+        --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
+        --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
 
     {
       # Starting with the image tag with the _base suffix
@@ -108,9 +118,13 @@ clamav_db_update() {
       # Update the database
       echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
     } | \
-      docker buildx build --platform linux/ppc64le --pull --rm --push \
-        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
-
+      docker buildx build --platform linux/ppc64le --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+        --annotation "org.opencontainers.image.url=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.source=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
+        --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
+        --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
+        --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
   done
 
   docker buildx imagetools create -t "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \

--- a/clamav/unstable/alpine/Jenkinsfile
+++ b/clamav/unstable/alpine/Jenkinsfile
@@ -64,14 +64,14 @@ node('docker') {
                 //
 
                 sh """
-                docker build --no-cache --tag "${params.IMAGE_NAME}:unstable_base" .
-
-                # Make a tag with the registry name in it so we can push wherever
-                docker image tag ${params.IMAGE_NAME}:unstable_base ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base
-
-                # Push the image/tag
-                docker image push ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base
-                """
+                docker build --no-cache \
+                    --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                    --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                    --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                    --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                    --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                    --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                    --tag "${params.IMAGE_NAME}:unstable_base" --push .
 
                 // Give it some time to add the new unstable_base image.
                 // In past jobs, it didn't detect the new image until we re-ran this job. I suspect because it needed a little delay after pushing before pulling.

--- a/clamav/unstable/alpine/Jenkinsfile
+++ b/clamav/unstable/alpine/Jenkinsfile
@@ -68,8 +68,6 @@ node('docker') {
                     --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
                     --annotation org.opencontainers.image.url=${params.REPOSITORY} \
                     --annotation org.opencontainers.image.source=${params.REPOSITORY} \
-                    --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
-                    --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
                     --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
                     --tag "${params.IMAGE_NAME}:unstable_base" --push .
                 """

--- a/clamav/unstable/alpine/Jenkinsfile
+++ b/clamav/unstable/alpine/Jenkinsfile
@@ -72,6 +72,7 @@ node('docker') {
                     --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
                     --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
                     --tag "${params.IMAGE_NAME}:unstable_base" --push .
+                """
 
                 // Give it some time to add the new unstable_base image.
                 // In past jobs, it didn't detect the new image until we re-ran this job. I suspect because it needed a little delay after pushing before pulling.

--- a/clamav/unstable/alpine/Jenkinsfile
+++ b/clamav/unstable/alpine/Jenkinsfile
@@ -69,7 +69,7 @@ node('docker') {
                     --annotation org.opencontainers.image.url=${params.REPOSITORY} \
                     --annotation org.opencontainers.image.source=${params.REPOSITORY} \
                     --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
-                    --tag "${params.IMAGE_NAME}:unstable_base" --push .
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base --push .
                 """
 
                 // Give it some time to add the new unstable_base image.

--- a/clamav/unstable/alpine/Jenkinsfile
+++ b/clamav/unstable/alpine/Jenkinsfile
@@ -64,7 +64,7 @@ node('docker') {
                 //
 
                 sh """
-                docker build --no-cache \
+                docker buildx build --no-cache \
                     --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
                     --annotation org.opencontainers.image.url=${params.REPOSITORY} \
                     --annotation org.opencontainers.image.source=${params.REPOSITORY} \

--- a/clamav/unstable/alpine/scripts/update_db_image.sh
+++ b/clamav/unstable/alpine/scripts/update_db_image.sh
@@ -92,9 +92,13 @@ clamav_db_update()
 			echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
 		} | \
 		# Pull and Build the updated image with the tag without the _base suffix.
-		docker image build --pull --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" -
-		# Push the updated image with the tag without the _base suffix.
-		docker image push "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}"
+    docker build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+       --annotation "org.opencontainers.image.url=${REPOSITORY}" \
+       --annotation "org.opencontainers.image.source=${REPOSITORY}" \
+       --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
+       --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
+       --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
+       --pull --push --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" -
 	done
 }
 

--- a/clamav/unstable/alpine/scripts/update_db_image.sh
+++ b/clamav/unstable/alpine/scripts/update_db_image.sh
@@ -92,7 +92,7 @@ clamav_db_update()
 			echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
 		} | \
 		# Pull and Build the updated image with the tag without the _base suffix.
-    docker build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+    docker buildx build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
        --annotation "org.opencontainers.image.url=${REPOSITORY}" \
        --annotation "org.opencontainers.image.source=${REPOSITORY}" \
        --annotation "org.opencontainers.image.created=$(date -Iseconds)" \

--- a/clamav/unstable/alpine/scripts/update_db_image.sh
+++ b/clamav/unstable/alpine/scripts/update_db_image.sh
@@ -95,8 +95,6 @@ clamav_db_update()
     docker build --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
        --annotation "org.opencontainers.image.url=${REPOSITORY}" \
        --annotation "org.opencontainers.image.source=${REPOSITORY}" \
-       --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
-       --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
        --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
        --pull --push --rm --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" -
 	done

--- a/clamav/unstable/debian/Jenkinsfile
+++ b/clamav/unstable/debian/Jenkinsfile
@@ -75,7 +75,14 @@ node('macos-newer') {
 
                 // Build 'unstable' and 'unstable_base' images.
                 sh """
-                docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base --push .
+                docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
+                    --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                    --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                    --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                    --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                    --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                    --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base --push .
                 """
 
                 // Give it some time to add the new unstable_base image.

--- a/clamav/unstable/debian/Jenkinsfile
+++ b/clamav/unstable/debian/Jenkinsfile
@@ -79,8 +79,6 @@ node('macos-newer') {
                     --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
                     --annotation org.opencontainers.image.url=${params.REPOSITORY} \
                     --annotation org.opencontainers.image.source=${params.REPOSITORY} \
-                    --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
-                    --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
                     --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
                     --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base --push .
                 """

--- a/clamav/unstable/debian/Jenkinsfile
+++ b/clamav/unstable/debian/Jenkinsfile
@@ -87,7 +87,7 @@ node('macos-newer') {
 
                 // Give it some time to add the new unstable_base image.
                 // In past jobs, it didn't detect the new image until we re-ran this job. I suspect because it needed a little delay after pushing before pulling.
-                """
+                sh """
                 sleep 20
                 """
 

--- a/clamav/unstable/debian/scripts/update_db_image.sh
+++ b/clamav/unstable/debian/scripts/update_db_image.sh
@@ -59,8 +59,8 @@ docker_tags_get() {
     tr '}' '\n' |
     sed -n -e 's|.*name:\(.*\)$|\1|p')"
 
-	echo "Tags:"
-	echo "${_tags}"
+  echo "Tags:"
+  echo "${_tags}"
 
   for _tag in ${_tags}; do
     # Only get the tags that have the _base suffix
@@ -90,8 +90,13 @@ clamav_db_update() {
       # Update the database
       echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
     } | \
-      docker buildx build --platform linux/amd64 --pull --rm --push \
-        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
+      docker buildx build --platform linux/amd64 --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+        --annotation "org.opencontainers.image.url=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.source=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
+        --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
+        --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
+        --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
 
     {
       # Starting with the image tag with the _base suffix
@@ -99,8 +104,13 @@ clamav_db_update() {
       # Update the database
       echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
     } | \
-      docker buildx build --platform linux/arm64 --pull --rm --push \
-        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
+      docker buildx build --platform linux/arm64 --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+        --annotation "org.opencontainers.image.url=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.source=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
+        --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
+        --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
+        --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
 
     {
       # Starting with the image tag with the _base suffix
@@ -108,9 +118,13 @@ clamav_db_update() {
       # Update the database
       echo "RUN freshclam --foreground --stdout && rm /var/lib/clamav/freshclam.dat || rm /var/lib/clamav/mirrors.dat || true"
     } | \
-      docker buildx build --platform linux/ppc64le --pull --rm --push \
-        --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
-
+      docker buildx build --platform linux/ppc64le --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
+        --annotation "org.opencontainers.image.url=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.source=${REPOSITORY}" \
+        --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
+        --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
+        --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
+        --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
   done
 
   docker buildx imagetools create -t "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}" \

--- a/clamav/unstable/debian/scripts/update_db_image.sh
+++ b/clamav/unstable/debian/scripts/update_db_image.sh
@@ -93,8 +93,6 @@ clamav_db_update() {
       docker buildx build --platform linux/amd64 --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
         --annotation "org.opencontainers.image.url=${REPOSITORY}" \
         --annotation "org.opencontainers.image.source=${REPOSITORY}" \
-        --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
-        --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
         --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
         --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-amd64" -
 
@@ -107,8 +105,6 @@ clamav_db_update() {
       docker buildx build --platform linux/arm64 --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
         --annotation "org.opencontainers.image.url=${REPOSITORY}" \
         --annotation "org.opencontainers.image.source=${REPOSITORY}" \
-        --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
-        --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
         --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
         --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-arm64" -
 
@@ -121,8 +117,6 @@ clamav_db_update() {
       docker buildx build --platform linux/ppc64le --sbom=true --provenance mode=max,builder-id="${BUILD_URL}" \
         --annotation "org.opencontainers.image.url=${REPOSITORY}" \
         --annotation "org.opencontainers.image.source=${REPOSITORY}" \
-        --annotation "org.opencontainers.image.version=${FULL_VERSION}" \
-        --annotation "org.opencontainers.image.ref.name=${BRANCH}" \
         --annotation "org.opencontainers.image.created=$(date -Iseconds)" \
         --pull --rm --push --tag "${docker_registry}/${clamav_docker_namespace}/${clamav_docker_image}:${_tag%%_base}-ppc64le" -
   done


### PR DESCRIPTION
Adding annotations, attestations and SBOM for ClamAV (Apline/Debian) and Clam-bytecode-compiler(ubuntu) docker images.

Changes are added for "_base" image and db image wherever applicable.

**Test Images built**
ClamAV Debian-based image - docker pull micasnyd/clamav-debian:1.4.1-6
ClamAV Alpine-based image - docker pull micasnyd/clamav:1.4.1-21
ClamBC image - docker pull micasnyd/clambc-compiler:1.4.0-2

Replaces and extends #55
@candrews Thanks for starting the work and helping the ClamAV team to add these changes. 