### PR TITLE
Remove PidFile configuration

### DIFF
--- a/clamav/1.0/alpine/Dockerfile
+++ b/clamav/1.0/alpine/Dockerfile
@@ -60,7 +60,6 @@ RUN apk update && apk upgrade \
        "/clamav/usr/lib/pkgconfig/" \
     && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/clamd.pid|" \
         -e "s|.*\(LocalSocket\) .*|\1 /tmp/clamd.sock|" \
         -e "s|.*\(TCPSocket\) .*|\1 3310|" \
         -e "s|.*\(TCPAddr\) .*|#\1 0.0.0.0|" \
@@ -69,14 +68,12 @@ RUN apk update && apk upgrade \
         -e "s|^\#\(LogTime\).*|\1 yes|" \
         "/clamav/etc/clamav/clamd.conf.sample" > "/clamav/etc/clamav/clamd.conf" && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/freshclam.pid|" \
         -e "s|.*\(DatabaseOwner\) .*|\1 clamav|" \
         -e "s|^\#\(UpdateLogFile\) .*|\1 /var/log/clamav/freshclam.log|" \
         -e "s|^\#\(NotifyClamd\).*|\1 /etc/clamav/clamd.conf|" \
         -e "s|^\#\(ScriptedUpdates\).*|\1 yes|" \
         "/clamav/etc/clamav/freshclam.conf.sample" > "/clamav/etc/clamav/freshclam.conf" && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/clamav-milter.pid|" \
         -e "s|.*\(MilterSocket\) .*|\1 inet:7357|" \
         -e "s|.*\(User\) .*|\1 clamav|" \
         -e "s|^\#\(LogFile\) .*|\1 /var/log/clamav/milter.log|" \

--- a/clamav/1.0/debian/Dockerfile
+++ b/clamav/1.0/debian/Dockerfile
@@ -69,7 +69,6 @@ RUN apt update && apt install -y \
        "/clamav/usr/lib/pkgconfig/" \
     && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/clamd.pid|" \
         -e "s|.*\(LocalSocket\) .*|\1 /tmp/clamd.sock|" \
         -e "s|.*\(TCPSocket\) .*|\1 3310|" \
         -e "s|.*\(TCPAddr\) .*|#\1 0.0.0.0|" \
@@ -78,14 +77,12 @@ RUN apt update && apt install -y \
         -e "s|^\#\(LogTime\).*|\1 yes|" \
         "/clamav/etc/clamav/clamd.conf.sample" > "/clamav/etc/clamav/clamd.conf" && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/freshclam.pid|" \
         -e "s|.*\(DatabaseOwner\) .*|\1 clamav|" \
         -e "s|^\#\(UpdateLogFile\) .*|\1 /var/log/clamav/freshclam.log|" \
         -e "s|^\#\(NotifyClamd\).*|\1 /etc/clamav/clamd.conf|" \
         -e "s|^\#\(ScriptedUpdates\).*|\1 yes|" \
         "/clamav/etc/clamav/freshclam.conf.sample" > "/clamav/etc/clamav/freshclam.conf" && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/clamav-milter.pid|" \
         -e "s|.*\(MilterSocket\) .*|\1 inet:7357|" \
         -e "s|.*\(User\) .*|\1 clamav|" \
         -e "s|^\#\(LogFile\) .*|\1 /var/log/clamav/milter.log|" \

--- a/clamav/1.3/alpine/Dockerfile
+++ b/clamav/1.3/alpine/Dockerfile
@@ -60,7 +60,6 @@ RUN apk update && apk upgrade \
        "/clamav/usr/lib/pkgconfig/" \
     && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/clamd.pid|" \
         -e "s|.*\(LocalSocket\) .*|\1 /tmp/clamd.sock|" \
         -e "s|.*\(TCPSocket\) .*|\1 3310|" \
         -e "s|.*\(TCPAddr\) .*|#\1 0.0.0.0|" \
@@ -69,14 +68,12 @@ RUN apk update && apk upgrade \
         -e "s|^\#\(LogTime\).*|\1 yes|" \
         "/clamav/etc/clamav/clamd.conf.sample" > "/clamav/etc/clamav/clamd.conf" && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/freshclam.pid|" \
         -e "s|.*\(DatabaseOwner\) .*|\1 clamav|" \
         -e "s|^\#\(UpdateLogFile\) .*|\1 /var/log/clamav/freshclam.log|" \
         -e "s|^\#\(NotifyClamd\).*|\1 /etc/clamav/clamd.conf|" \
         -e "s|^\#\(ScriptedUpdates\).*|\1 yes|" \
         "/clamav/etc/clamav/freshclam.conf.sample" > "/clamav/etc/clamav/freshclam.conf" && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/clamav-milter.pid|" \
         -e "s|.*\(MilterSocket\) .*|\1 inet:7357|" \
         -e "s|.*\(User\) .*|\1 clamav|" \
         -e "s|^\#\(LogFile\) .*|\1 /var/log/clamav/milter.log|" \

--- a/clamav/1.3/debian/Dockerfile
+++ b/clamav/1.3/debian/Dockerfile
@@ -69,7 +69,6 @@ RUN apt update && apt install -y \
        "/clamav/usr/lib/pkgconfig/" \
     && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/clamd.pid|" \
         -e "s|.*\(LocalSocket\) .*|\1 /tmp/clamd.sock|" \
         -e "s|.*\(TCPSocket\) .*|\1 3310|" \
         -e "s|.*\(TCPAddr\) .*|#\1 0.0.0.0|" \
@@ -78,14 +77,12 @@ RUN apt update && apt install -y \
         -e "s|^\#\(LogTime\).*|\1 yes|" \
         "/clamav/etc/clamav/clamd.conf.sample" > "/clamav/etc/clamav/clamd.conf" && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/freshclam.pid|" \
         -e "s|.*\(DatabaseOwner\) .*|\1 clamav|" \
         -e "s|^\#\(UpdateLogFile\) .*|\1 /var/log/clamav/freshclam.log|" \
         -e "s|^\#\(NotifyClamd\).*|\1 /etc/clamav/clamd.conf|" \
         -e "s|^\#\(ScriptedUpdates\).*|\1 yes|" \
         "/clamav/etc/clamav/freshclam.conf.sample" > "/clamav/etc/clamav/freshclam.conf" && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/clamav-milter.pid|" \
         -e "s|.*\(MilterSocket\) .*|\1 inet:7357|" \
         -e "s|.*\(User\) .*|\1 clamav|" \
         -e "s|^\#\(LogFile\) .*|\1 /var/log/clamav/milter.log|" \

--- a/clamav/1.4/alpine/Dockerfile
+++ b/clamav/1.4/alpine/Dockerfile
@@ -60,7 +60,6 @@ RUN apk update && apk upgrade \
        "/clamav/usr/lib/pkgconfig/" \
     && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/clamd.pid|" \
         -e "s|.*\(LocalSocket\) .*|\1 /tmp/clamd.sock|" \
         -e "s|.*\(TCPSocket\) .*|\1 3310|" \
         -e "s|.*\(TCPAddr\) .*|#\1 0.0.0.0|" \
@@ -69,14 +68,12 @@ RUN apk update && apk upgrade \
         -e "s|^\#\(LogTime\).*|\1 yes|" \
         "/clamav/etc/clamav/clamd.conf.sample" > "/clamav/etc/clamav/clamd.conf" && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/freshclam.pid|" \
         -e "s|.*\(DatabaseOwner\) .*|\1 clamav|" \
         -e "s|^\#\(UpdateLogFile\) .*|\1 /var/log/clamav/freshclam.log|" \
         -e "s|^\#\(NotifyClamd\).*|\1 /etc/clamav/clamd.conf|" \
         -e "s|^\#\(ScriptedUpdates\).*|\1 yes|" \
         "/clamav/etc/clamav/freshclam.conf.sample" > "/clamav/etc/clamav/freshclam.conf" && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/clamav-milter.pid|" \
         -e "s|.*\(MilterSocket\) .*|\1 inet:7357|" \
         -e "s|.*\(User\) .*|\1 clamav|" \
         -e "s|^\#\(LogFile\) .*|\1 /var/log/clamav/milter.log|" \

--- a/clamav/1.4/debian/Dockerfile
+++ b/clamav/1.4/debian/Dockerfile
@@ -69,7 +69,6 @@ RUN apt update && apt install -y \
        "/clamav/usr/lib/pkgconfig/" \
     && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/clamd.pid|" \
         -e "s|.*\(LocalSocket\) .*|\1 /tmp/clamd.sock|" \
         -e "s|.*\(TCPSocket\) .*|\1 3310|" \
         -e "s|.*\(TCPAddr\) .*|#\1 0.0.0.0|" \
@@ -78,14 +77,12 @@ RUN apt update && apt install -y \
         -e "s|^\#\(LogTime\).*|\1 yes|" \
         "/clamav/etc/clamav/clamd.conf.sample" > "/clamav/etc/clamav/clamd.conf" && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/freshclam.pid|" \
         -e "s|.*\(DatabaseOwner\) .*|\1 clamav|" \
         -e "s|^\#\(UpdateLogFile\) .*|\1 /var/log/clamav/freshclam.log|" \
         -e "s|^\#\(NotifyClamd\).*|\1 /etc/clamav/clamd.conf|" \
         -e "s|^\#\(ScriptedUpdates\).*|\1 yes|" \
         "/clamav/etc/clamav/freshclam.conf.sample" > "/clamav/etc/clamav/freshclam.conf" && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/clamav-milter.pid|" \
         -e "s|.*\(MilterSocket\) .*|\1 inet:7357|" \
         -e "s|.*\(User\) .*|\1 clamav|" \
         -e "s|^\#\(LogFile\) .*|\1 /var/log/clamav/milter.log|" \

--- a/clamav/unstable/alpine/Dockerfile
+++ b/clamav/unstable/alpine/Dockerfile
@@ -60,7 +60,6 @@ RUN apk update && apk upgrade \
        "/clamav/usr/lib/pkgconfig/" \
     && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/clamd.pid|" \
         -e "s|.*\(LocalSocket\) .*|\1 /tmp/clamd.sock|" \
         -e "s|.*\(TCPSocket\) .*|\1 3310|" \
         -e "s|.*\(TCPAddr\) .*|#\1 0.0.0.0|" \
@@ -69,14 +68,12 @@ RUN apk update && apk upgrade \
         -e "s|^\#\(LogTime\).*|\1 yes|" \
         "/clamav/etc/clamav/clamd.conf.sample" > "/clamav/etc/clamav/clamd.conf" && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/freshclam.pid|" \
         -e "s|.*\(DatabaseOwner\) .*|\1 clamav|" \
         -e "s|^\#\(UpdateLogFile\) .*|\1 /var/log/clamav/freshclam.log|" \
         -e "s|^\#\(NotifyClamd\).*|\1 /etc/clamav/clamd.conf|" \
         -e "s|^\#\(ScriptedUpdates\).*|\1 yes|" \
         "/clamav/etc/clamav/freshclam.conf.sample" > "/clamav/etc/clamav/freshclam.conf" && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/clamav-milter.pid|" \
         -e "s|.*\(MilterSocket\) .*|\1 inet:7357|" \
         -e "s|.*\(User\) .*|\1 clamav|" \
         -e "s|^\#\(LogFile\) .*|\1 /var/log/clamav/milter.log|" \

--- a/clamav/unstable/debian/Dockerfile
+++ b/clamav/unstable/debian/Dockerfile
@@ -69,7 +69,6 @@ RUN apt update && apt install -y \
        "/clamav/usr/lib/pkgconfig/" \
     && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/clamd.pid|" \
         -e "s|.*\(LocalSocket\) .*|\1 /tmp/clamd.sock|" \
         -e "s|.*\(TCPSocket\) .*|\1 3310|" \
         -e "s|.*\(TCPAddr\) .*|#\1 0.0.0.0|" \
@@ -78,14 +77,12 @@ RUN apt update && apt install -y \
         -e "s|^\#\(LogTime\).*|\1 yes|" \
         "/clamav/etc/clamav/clamd.conf.sample" > "/clamav/etc/clamav/clamd.conf" && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/freshclam.pid|" \
         -e "s|.*\(DatabaseOwner\) .*|\1 clamav|" \
         -e "s|^\#\(UpdateLogFile\) .*|\1 /var/log/clamav/freshclam.log|" \
         -e "s|^\#\(NotifyClamd\).*|\1 /etc/clamav/clamd.conf|" \
         -e "s|^\#\(ScriptedUpdates\).*|\1 yes|" \
         "/clamav/etc/clamav/freshclam.conf.sample" > "/clamav/etc/clamav/freshclam.conf" && \
     sed -e "s|^\(Example\)|\# \1|" \
-        -e "s|.*\(PidFile\) .*|\1 /tmp/clamav-milter.pid|" \
         -e "s|.*\(MilterSocket\) .*|\1 inet:7357|" \
         -e "s|.*\(User\) .*|\1 clamav|" \
         -e "s|^\#\(LogFile\) .*|\1 /var/log/clamav/milter.log|" \


### PR DESCRIPTION
There should be no need for freshclam, clamd, or clamav-milter to create a PID file.

There is a very minor security concern that the PID file is located in a user-writable directory in that a naive service manager might kill the wrong process if the PID file has been modified.

Granted, these Docker images do not have a service manager which operates in this way. However, I believe there is no harm in removing the PID files so as to eliminate the hypothetical risk if one were to use those PID files.

Refs:
- https://github.com/Cisco-Talos/clamav/issues/1076
- https://github.com/Cisco-Talos/clamav/commit/5b168b50cdd0c0650eca3047097a3f6919e8ab64