### PR TITLE
Set config for initial freshclam call

### DIFF
--- a/clamav/1.0/alpine/scripts/docker-entrypoint-unprivileged.sh
+++ b/clamav/1.0/alpine/scripts/docker-entrypoint-unprivileged.sh
@@ -27,7 +27,14 @@ else
 	# Ensure we have some virus data, otherwise clamd refuses to start
 	if [ ! -f "/var/lib/clamav/main.cvd" ]; then
 		echo "Updating initial database"
-		freshclam --foreground --stdout
+		
+		# Set "TestDatabases no" and remove "NotifyClamd" for initial download
+		sed -e 's|^\(TestDatabases \)|\#\1|' \
+			-e '$a TestDatabases no' \
+			-e 's|^\(NotifyClamd \)|\#\1|' \
+			/etc/clamav/freshclam.conf > /tmp/freshclam_initial.conf
+		freshclam --foreground --stdout --config-file=/tmp/freshclam_initial.conf
+		rm /tmp/freshclam_initial.conf
 	fi
 
 	if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then

--- a/clamav/1.0/alpine/scripts/docker-entrypoint.sh
+++ b/clamav/1.0/alpine/scripts/docker-entrypoint.sh
@@ -55,7 +55,14 @@ else
 	# Ensure we have some virus data, otherwise clamd refuses to start
 	if [ ! -f "/var/lib/clamav/main.cvd" ]; then
 		echo "Updating initial database"
-		freshclam --foreground --stdout
+		
+		# Set "TestDatabases no" and remove "NotifyClamd" for initial download
+		sed -e 's|^\(TestDatabases \)|\#\1|' \
+			-e '$a TestDatabases no' \
+			-e 's|^\(NotifyClamd \)|\#\1|' \
+			/etc/clamav/freshclam.conf > /tmp/freshclam_initial.conf
+		freshclam --foreground --stdout --config-file=/tmp/freshclam_initial.conf
+		rm /tmp/freshclam_initial.conf
 	fi
 
 	if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then

--- a/clamav/1.0/debian/scripts/docker-entrypoint-unprivileged.sh
+++ b/clamav/1.0/debian/scripts/docker-entrypoint-unprivileged.sh
@@ -27,7 +27,14 @@ else
 	# Ensure we have some virus data, otherwise clamd refuses to start
 	if [ ! -f "/var/lib/clamav/main.cvd" ]; then
 		echo "Updating initial database"
-		freshclam --foreground --stdout
+		
+		# Set "TestDatabases no" and remove "NotifyClamd" for initial download
+		sed -e 's|^\(TestDatabases \)|\#\1|' \
+			-e '$a TestDatabases no' \
+			-e 's|^\(NotifyClamd \)|\#\1|' \
+			/etc/clamav/freshclam.conf > /tmp/freshclam_initial.conf
+		freshclam --foreground --stdout --config-file=/tmp/freshclam_initial.conf
+		rm /tmp/freshclam_initial.conf
 	fi
 
 	if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then

--- a/clamav/1.0/debian/scripts/docker-entrypoint.sh
+++ b/clamav/1.0/debian/scripts/docker-entrypoint.sh
@@ -55,7 +55,14 @@ else
 	# Ensure we have some virus data, otherwise clamd refuses to start
 	if [ ! -f "/var/lib/clamav/main.cvd" ]; then
 		echo "Updating initial database"
-		freshclam --foreground --stdout
+		
+		# Set "TestDatabases no" and remove "NotifyClamd" for initial download
+		sed -e 's|^\(TestDatabases \)|\#\1|' \
+			-e '$a TestDatabases no' \
+			-e 's|^\(NotifyClamd \)|\#\1|' \
+			/etc/clamav/freshclam.conf > /tmp/freshclam_initial.conf
+		freshclam --foreground --stdout --config-file=/tmp/freshclam_initial.conf
+		rm /tmp/freshclam_initial.conf
 	fi
 
 	if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then

--- a/clamav/1.3/alpine/scripts/docker-entrypoint-unprivileged.sh
+++ b/clamav/1.3/alpine/scripts/docker-entrypoint-unprivileged.sh
@@ -27,7 +27,14 @@ else
 	# Ensure we have some virus data, otherwise clamd refuses to start
 	if [ ! -f "/var/lib/clamav/main.cvd" ]; then
 		echo "Updating initial database"
-		freshclam --foreground --stdout
+		
+		# Set "TestDatabases no" and remove "NotifyClamd" for initial download
+		sed -e 's|^\(TestDatabases \)|\#\1|' \
+			-e '$a TestDatabases no' \
+			-e 's|^\(NotifyClamd \)|\#\1|' \
+			/etc/clamav/freshclam.conf > /tmp/freshclam_initial.conf
+		freshclam --foreground --stdout --config-file=/tmp/freshclam_initial.conf
+		rm /tmp/freshclam_initial.conf
 	fi
 
 	if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then

--- a/clamav/1.3/alpine/scripts/docker-entrypoint.sh
+++ b/clamav/1.3/alpine/scripts/docker-entrypoint.sh
@@ -55,7 +55,14 @@ else
 	# Ensure we have some virus data, otherwise clamd refuses to start
 	if [ ! -f "/var/lib/clamav/main.cvd" ]; then
 		echo "Updating initial database"
-		freshclam --foreground --stdout
+		
+		# Set "TestDatabases no" and remove "NotifyClamd" for initial download
+		sed -e 's|^\(TestDatabases \)|\#\1|' \
+			-e '$a TestDatabases no' \
+			-e 's|^\(NotifyClamd \)|\#\1|' \
+			/etc/clamav/freshclam.conf > /tmp/freshclam_initial.conf
+		freshclam --foreground --stdout --config-file=/tmp/freshclam_initial.conf
+		rm /tmp/freshclam_initial.conf
 	fi
 
 	if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then

--- a/clamav/1.3/debian/scripts/docker-entrypoint-unprivileged.sh
+++ b/clamav/1.3/debian/scripts/docker-entrypoint-unprivileged.sh
@@ -27,7 +27,14 @@ else
 	# Ensure we have some virus data, otherwise clamd refuses to start
 	if [ ! -f "/var/lib/clamav/main.cvd" ]; then
 		echo "Updating initial database"
-		freshclam --foreground --stdout
+		
+		# Set "TestDatabases no" and remove "NotifyClamd" for initial download
+		sed -e 's|^\(TestDatabases \)|\#\1|' \
+			-e '$a TestDatabases no' \
+			-e 's|^\(NotifyClamd \)|\#\1|' \
+			/etc/clamav/freshclam.conf > /tmp/freshclam_initial.conf
+		freshclam --foreground --stdout --config-file=/tmp/freshclam_initial.conf
+		rm /tmp/freshclam_initial.conf
 	fi
 
 	if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then

--- a/clamav/1.3/debian/scripts/docker-entrypoint.sh
+++ b/clamav/1.3/debian/scripts/docker-entrypoint.sh
@@ -55,7 +55,14 @@ else
 	# Ensure we have some virus data, otherwise clamd refuses to start
 	if [ ! -f "/var/lib/clamav/main.cvd" ]; then
 		echo "Updating initial database"
-		freshclam --foreground --stdout
+		
+		# Set "TestDatabases no" and remove "NotifyClamd" for initial download
+		sed -e 's|^\(TestDatabases \)|\#\1|' \
+			-e '$a TestDatabases no' \
+			-e 's|^\(NotifyClamd \)|\#\1|' \
+			/etc/clamav/freshclam.conf > /tmp/freshclam_initial.conf
+		freshclam --foreground --stdout --config-file=/tmp/freshclam_initial.conf
+		rm /tmp/freshclam_initial.conf
 	fi
 
 	if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then

--- a/clamav/1.4/alpine/scripts/docker-entrypoint-unprivileged.sh
+++ b/clamav/1.4/alpine/scripts/docker-entrypoint-unprivileged.sh
@@ -27,7 +27,13 @@ else
 	# Ensure we have some virus data, otherwise clamd refuses to start
 	if [ ! -f "/var/lib/clamav/main.cvd" ]; then
 		echo "Updating initial database"
-		freshclam --foreground --stdout
+		# Set "TestDatabases no" and remove "NotifyClamd" for initial download
+		sed -e 's|^\(TestDatabases \)|\#\1|' \
+			-e '$a TestDatabases no' \
+			-e 's|^\(NotifyClamd \)|\#\1|' \
+			/etc/clamav/freshclam.conf > /tmp/freshclam_initial.conf
+		freshclam --foreground --stdout --config-file=/tmp/freshclam_initial.conf
+		rm /tmp/freshclam_initial.conf
 	fi
 
 	if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then

--- a/clamav/1.4/alpine/scripts/docker-entrypoint.sh
+++ b/clamav/1.4/alpine/scripts/docker-entrypoint.sh
@@ -55,7 +55,13 @@ else
 	# Ensure we have some virus data, otherwise clamd refuses to start
 	if [ ! -f "/var/lib/clamav/main.cvd" ]; then
 		echo "Updating initial database"
-		freshclam --foreground --stdout
+		# Set "TestDatabases no" and remove "NotifyClamd" for initial download
+		sed -e 's|^\(TestDatabases \)|\#\1|' \
+			-e '$a TestDatabases no' \
+			-e 's|^\(NotifyClamd \)|\#\1|' \
+			/etc/clamav/freshclam.conf > /tmp/freshclam_initial.conf
+		freshclam --foreground --stdout --config-file=/tmp/freshclam_initial.conf
+		rm /tmp/freshclam_initial.conf
 	fi
 
 	if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then

--- a/clamav/1.4/debian/scripts/docker-entrypoint-unprivileged.sh
+++ b/clamav/1.4/debian/scripts/docker-entrypoint-unprivileged.sh
@@ -27,7 +27,13 @@ else
 	# Ensure we have some virus data, otherwise clamd refuses to start
 	if [ ! -f "/var/lib/clamav/main.cvd" ]; then
 		echo "Updating initial database"
-		freshclam --foreground --stdout
+		# Set "TestDatabases no" and remove "NotifyClamd" for initial download
+		sed -e 's|^\(TestDatabases \)|\#\1|' \
+			-e '$a TestDatabases no' \
+			-e 's|^\(NotifyClamd \)|\#\1|' \
+			/etc/clamav/freshclam.conf > /tmp/freshclam_initial.conf
+		freshclam --foreground --stdout --config-file=/tmp/freshclam_initial.conf
+		rm /tmp/freshclam_initial.conf
 	fi
 
 	if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then

--- a/clamav/1.4/debian/scripts/docker-entrypoint.sh
+++ b/clamav/1.4/debian/scripts/docker-entrypoint.sh
@@ -55,7 +55,13 @@ else
 	# Ensure we have some virus data, otherwise clamd refuses to start
 	if [ ! -f "/var/lib/clamav/main.cvd" ]; then
 		echo "Updating initial database"
-		freshclam --foreground --stdout
+		# Set "TestDatabases no" and remove "NotifyClamd" for initial download
+		sed -e 's|^\(TestDatabases \)|\#\1|' \
+			-e '$a TestDatabases no' \
+			-e 's|^\(NotifyClamd \)|\#\1|' \
+			/etc/clamav/freshclam.conf > /tmp/freshclam_initial.conf
+		freshclam --foreground --stdout --config-file=/tmp/freshclam_initial.conf
+		rm /tmp/freshclam_initial.conf
 	fi
 
 	if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then

--- a/clamav/unstable/alpine/scripts/docker-entrypoint-unprivileged.sh
+++ b/clamav/unstable/alpine/scripts/docker-entrypoint-unprivileged.sh
@@ -27,7 +27,14 @@ else
 	# Ensure we have some virus data, otherwise clamd refuses to start
 	if [ ! -f "/var/lib/clamav/main.cvd" ]; then
 		echo "Updating initial database"
-		freshclam --foreground --stdout
+		
+		# Set "TestDatabases no" and remove "NotifyClamd" for initial download
+		sed -e 's|^\(TestDatabases \)|\#\1|' \
+			-e '$a TestDatabases no' \
+			-e 's|^\(NotifyClamd \)|\#\1|' \
+			/etc/clamav/freshclam.conf > /tmp/freshclam_initial.conf
+		freshclam --foreground --stdout --config-file=/tmp/freshclam_initial.conf
+		rm /tmp/freshclam_initial.conf
 	fi
 
 	if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then

--- a/clamav/unstable/alpine/scripts/docker-entrypoint.sh
+++ b/clamav/unstable/alpine/scripts/docker-entrypoint.sh
@@ -55,7 +55,14 @@ else
 	# Ensure we have some virus data, otherwise clamd refuses to start
 	if [ ! -f "/var/lib/clamav/main.cvd" ]; then
 		echo "Updating initial database"
-		freshclam --foreground --stdout
+		
+		# Set "TestDatabases no" and remove "NotifyClamd" for initial download
+		sed -e 's|^\(TestDatabases \)|\#\1|' \
+			-e '$a TestDatabases no' \
+			-e 's|^\(NotifyClamd \)|\#\1|' \
+			/etc/clamav/freshclam.conf > /tmp/freshclam_initial.conf
+		freshclam --foreground --stdout --config-file=/tmp/freshclam_initial.conf
+		rm /tmp/freshclam_initial.conf
 	fi
 
 	if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then

--- a/clamav/unstable/debian/scripts/docker-entrypoint-unprivileged.sh
+++ b/clamav/unstable/debian/scripts/docker-entrypoint-unprivileged.sh
@@ -27,7 +27,14 @@ else
 	# Ensure we have some virus data, otherwise clamd refuses to start
 	if [ ! -f "/var/lib/clamav/main.cvd" ]; then
 		echo "Updating initial database"
-		freshclam --foreground --stdout
+		
+		# Set "TestDatabases no" and remove "NotifyClamd" for initial download
+		sed -e 's|^\(TestDatabases \)|\#\1|' \
+			-e '$a TestDatabases no' \
+			-e 's|^\(NotifyClamd \)|\#\1|' \
+			/etc/clamav/freshclam.conf > /tmp/freshclam_initial.conf
+		freshclam --foreground --stdout --config-file=/tmp/freshclam_initial.conf
+		rm /tmp/freshclam_initial.conf
 	fi
 
 	if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then

--- a/clamav/unstable/debian/scripts/docker-entrypoint.sh
+++ b/clamav/unstable/debian/scripts/docker-entrypoint.sh
@@ -55,7 +55,14 @@ else
 	# Ensure we have some virus data, otherwise clamd refuses to start
 	if [ ! -f "/var/lib/clamav/main.cvd" ]; then
 		echo "Updating initial database"
-		freshclam --foreground --stdout
+		
+		# Set "TestDatabases no" and remove "NotifyClamd" for initial download
+		sed -e 's|^\(TestDatabases \)|\#\1|' \
+			-e '$a TestDatabases no' \
+			-e 's|^\(NotifyClamd \)|\#\1|' \
+			/etc/clamav/freshclam.conf > /tmp/freshclam_initial.conf
+		freshclam --foreground --stdout --config-file=/tmp/freshclam_initial.conf
+		rm /tmp/freshclam_initial.conf
 	fi
 
 	if [ "${CLAMAV_NO_FRESHCLAMD:-false}" != "true" ]; then


### PR DESCRIPTION
The initial freshclam call is different from those later on:
- It doesn't have to verify the database, because clamd will do that immediately afterwards
- It cannot notify clamd, because it's not yet running (and complains about that)

This commit modifies the entrypoint script to alter the usual freshclam.conf with "TestDatabases no" and "NotifyClamd no".