### PR TITLE
fix(debian): clean apt caches and add user

### DIFF
--- a/clamav/1.0/alpine/Dockerfile
+++ b/clamav/1.0/alpine/Dockerfile
@@ -111,7 +111,9 @@ RUN apk add --no-cache \
     addgroup -S "clamav" && \
     adduser -D -G "clamav" -h "/var/lib/clamav" -s "/bin/false" -u 100 -S "clamav" && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
-    chown -R clamav:clamav /var/lib/clamav
+    chown -R clamav:clamav /var/lib/clamav && \
+    chown -R clamav:clamav /run
+
 
 COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"

--- a/clamav/1.0/debian/Dockerfile
+++ b/clamav/1.0/debian/Dockerfile
@@ -121,7 +121,9 @@ RUN apt-get update && apt-get install -y \
     groupadd -g 1000 "clamav" && \
     useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 1000 -c "Clam Antivirus" clamav && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
-    chown -R clamav:clamav /var/lib/clamav
+    chown -R clamav:clamav /var/lib/clamav && \
+    chown -R clamav:clamav /run
+
 
 USER clamav
 

--- a/clamav/1.0/debian/Dockerfile
+++ b/clamav/1.0/debian/Dockerfile
@@ -116,11 +116,14 @@ RUN apt-get update && apt-get install -y \
         tzdata \
         netcat-openbsd \
     && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/archives && \
     groupadd -g 1000 "clamav" && \
     useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 1000 -c "Clam Antivirus" clamav && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
     chown -R clamav:clamav /var/lib/clamav
+
+USER clamav
 
 COPY --from=builder "/clamav" "/"
 

--- a/clamav/1.3/alpine/Dockerfile
+++ b/clamav/1.3/alpine/Dockerfile
@@ -111,7 +111,9 @@ RUN apk add --no-cache \
     addgroup -S "clamav" && \
     adduser -D -G "clamav" -h "/var/lib/clamav" -s "/bin/false" -u 100 -S "clamav" && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
-    chown -R clamav:clamav /var/lib/clamav
+    chown -R clamav:clamav /var/lib/clamav && \
+    chown -R clamav:clamav /run
+
 
 COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"

--- a/clamav/1.3/debian/Dockerfile
+++ b/clamav/1.3/debian/Dockerfile
@@ -121,7 +121,9 @@ RUN apt-get update && apt-get install -y \
     groupadd -g 1000 "clamav" && \
     useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 1000 -c "Clam Antivirus" clamav && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
-    chown -R clamav:clamav /var/lib/clamav
+    chown -R clamav:clamav /var/lib/clamav && \
+    chown -R clamav:clamav /run
+
 
 USER clamav
 

--- a/clamav/1.3/debian/Dockerfile
+++ b/clamav/1.3/debian/Dockerfile
@@ -116,11 +116,14 @@ RUN apt-get update && apt-get install -y \
         tzdata \
         netcat-openbsd \
     && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/archives && \
     groupadd -g 1000 "clamav" && \
     useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 1000 -c "Clam Antivirus" clamav && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
     chown -R clamav:clamav /var/lib/clamav
+
+USER clamav
 
 COPY --from=builder "/clamav" "/"
 

--- a/clamav/1.4/alpine/Dockerfile
+++ b/clamav/1.4/alpine/Dockerfile
@@ -111,7 +111,8 @@ RUN apk add --no-cache \
     addgroup -S "clamav" && \
     adduser -D -G "clamav" -h "/var/lib/clamav" -s "/bin/false" -u 100 -S "clamav" && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
-    chown -R clamav:clamav /var/lib/clamav
+    chown -R clamav:clamav /var/lib/clamav && \
+    chown -R clamav:clamav /run
 
 COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"

--- a/clamav/1.4/debian/Dockerfile
+++ b/clamav/1.4/debian/Dockerfile
@@ -121,7 +121,8 @@ RUN apt-get update && apt-get install -y \
     groupadd -g 1000 "clamav" && \
     useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 1000 -c "Clam Antivirus" clamav && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
-    chown -R clamav:clamav /var/lib/clamav
+    chown -R clamav:clamav /var/lib/clamav && \
+    chown -R clamav:clamav /run
 
 USER clamav
 

--- a/clamav/1.4/debian/Dockerfile
+++ b/clamav/1.4/debian/Dockerfile
@@ -116,11 +116,14 @@ RUN apt-get update && apt-get install -y \
         tzdata \
         netcat-openbsd \
     && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/archives && \
     groupadd -g 1000 "clamav" && \
     useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 1000 -c "Clam Antivirus" clamav && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
     chown -R clamav:clamav /var/lib/clamav
+
+USER clamav
 
 COPY --from=builder "/clamav" "/"
 

--- a/clamav/unstable/alpine/Dockerfile
+++ b/clamav/unstable/alpine/Dockerfile
@@ -111,7 +111,9 @@ RUN apk add --no-cache \
     addgroup -S "clamav" && \
     adduser -D -G "clamav" -h "/var/lib/clamav" -s "/bin/false" -u 100 -S "clamav" && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
-    chown -R clamav:clamav /var/lib/clamav
+    chown -R clamav:clamav /var/lib/clamav && \
+    chown -R clamav:clamav /run
+
 
 COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"

--- a/clamav/unstable/debian/Dockerfile
+++ b/clamav/unstable/debian/Dockerfile
@@ -121,7 +121,9 @@ RUN apt-get update && apt-get install -y \
     groupadd -g 1000 "clamav" && \
     useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 1000 -c "Clam Antivirus" clamav && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
-    chown -R clamav:clamav /var/lib/clamav
+    chown -R clamav:clamav /var/lib/clamav && \
+    chown -R clamav:clamav /run
+
 
 USER clamav
 

--- a/clamav/unstable/debian/Dockerfile
+++ b/clamav/unstable/debian/Dockerfile
@@ -116,11 +116,14 @@ RUN apt-get update && apt-get install -y \
         tzdata \
         netcat-openbsd \
     && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/archives && \
     groupadd -g 1000 "clamav" && \
     useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 1000 -c "Clam Antivirus" clamav && \
     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
     chown -R clamav:clamav /var/lib/clamav
+
+USER clamav
 
 COPY --from=builder "/clamav" "/"
 


### PR DESCRIPTION
First of all, thanks for the maintenance!

Minor fixes here:

1. User directive wasn't used, see [CIS-DI-0001](https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#cis-di-0001)

2. apt caches not cleaned, see [DKL-DI-0005](https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005) 

___

Currently, the following WARN+ issues are found by `dockle`:
```
> docker run --rm -v /var/run/docker.sock:/var/run/docker.sock goodwithtech/dockle:v0.4.15 --exit-code=1 --exit-level=warn clamav/clamav-debian:1.4

FATAL   - DKL-DI-0005: Clear apt-get caches
        * Use 'rm -rf /var/lib/apt/lists' after 'apt-get install|update' : RUN /bin/sh -c apt-get update && apt-get install -y         libbz2-1.0         libcurl4         libssl3         libjson-c5         libmilt
er1.0.1         libncurses6         libpcre2-8-0         libxml2         zlib1g         tzdata         netcat-openbsd     &&     rm -rf /var/cache/apt/archives &&     groupadd -g 1000 "clamav" &&     useradd -m -g
 clamav -s /bin/false --home-dir /var/lib/clamav -u 1000 -c "Clam Antivirus" clamav &&     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" &&     chown -R clamav:clamav /var/lib/clamav # buildkit
WARN    - CIS-DI-0001: Create a user for the container
        * Last user should not be root
```

This PR eliminates these issues