### PR TITLE
fix(debian): clean apt caches

### DIFF
--- a/clamav/1.0/debian/Dockerfile
+++ b/clamav/1.0/debian/Dockerfile
@@ -116,6 +116,7 @@ RUN apt-get update && apt-get install -y \
         tzdata \
         netcat-openbsd \
     && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/archives && \
     groupadd -g 1000 "clamav" && \
     useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 1000 -c "Clam Antivirus" clamav && \

--- a/clamav/1.4/debian/Dockerfile
+++ b/clamav/1.4/debian/Dockerfile
@@ -116,6 +116,7 @@ RUN apt-get update && apt-get install -y \
         tzdata \
         netcat-openbsd \
     && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/archives && \
     groupadd -g 1000 "clamav" && \
     useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 1000 -c "Clam Antivirus" clamav && \

--- a/clamav/unstable/debian/Dockerfile
+++ b/clamav/unstable/debian/Dockerfile
@@ -116,6 +116,7 @@ RUN apt-get update && apt-get install -y \
         tzdata \
         netcat-openbsd \
     && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/cache/apt/archives && \
     groupadd -g 1000 "clamav" && \
     useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 1000 -c "Clam Antivirus" clamav && \


### PR DESCRIPTION
First of all, thanks for the maintenance!

Here is a minor fix of not cleaned apt caches, see [DKL-DI-0005](https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#dkl-di-0005) 

___

Currently, the following `FATAL` issues are found by `dockle`:
```
> docker run --rm -v /var/run/docker.sock:/var/run/docker.sock goodwithtech/dockle:v0.4.15 --exit-code=1 --exit-level=warn clamav/clamav-debian:1.4

FATAL   - DKL-DI-0005: Clear apt-get caches
        * Use 'rm -rf /var/lib/apt/lists' after 'apt-get install|update' : RUN /bin/sh -c apt-get update && apt-get install -y         libbz2-1.0         libcurl4         libssl3         libjson-c5         libmilt
er1.0.1         libncurses6         libpcre2-8-0         libxml2         zlib1g         tzdata         netcat-openbsd     &&     rm -rf /var/cache/apt/archives &&     groupadd -g 1000 "clamav" &&     useradd -m -g
 clamav -s /bin/false --home-dir /var/lib/clamav -u 1000 -c "Clam Antivirus" clamav &&     install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" &&     chown -R clamav:clamav /var/lib/clamav # buildkit
```

This PR eliminates this issue