### PR TITLE
Clamav debian serial build

### DIFF
--- a/clamav/1.0/debian/Dockerfile
+++ b/clamav/1.0/debian/Dockerfile
@@ -91,7 +91,7 @@ RUN apt update && apt install -y \
         "/clamav/etc/clamav/clamav-milter.conf.sample" > "/clamav/etc/clamav/clamav-milter.conf" || \
     exit 1 \
     && \
-    ctest -V
+    ctest -V --timeout 3000
 
 FROM index.docker.io/library/debian:12-slim
 

--- a/clamav/1.0/debian/Jenkinsfile
+++ b/clamav/1.0/debian/Jenkinsfile
@@ -88,38 +88,58 @@ node('macos-newer') {
                 //
 
                 // Build X.Y.Z-R_base image.
+                sh """
+                    docker buildx build --no-cache --platform linux/amd64 \
+                        --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                        --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                        --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                        --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                        --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                        --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base-amd64 \
+                        --rm --push .
+
+                    docker buildx build --no-cache --platform linux/arm64 \
+                        --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                        --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                        --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                        --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                        --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                        --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base-arm64 \
+                        --rm --push .
+
+                    docker buildx build --no-cache --platform linux/ppc64le \
+                        --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                        --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                        --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                        --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                        --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                        --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base-ppc64le \
+                        --rm --push .
+
+                    docker buildx imagetools create -t ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                        "${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base-amd64" \
+                        "${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base-arm64" \
+                        "${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base-ppc64le"
+                """
 
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
-                        docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
-                            --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
-                            --annotation org.opencontainers.image.url=${params.REPOSITORY} \
-                            --annotation org.opencontainers.image.source=${params.REPOSITORY} \
-                            --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
-                            --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
-                            --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                        docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
-                            --push .
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base
                     """
                 }
                 else {
                     sh """
-                        docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
-                            --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
-                            --annotation org.opencontainers.image.url=${params.REPOSITORY} \
-                            --annotation org.opencontainers.image.source=${params.REPOSITORY} \
-                            --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
-                            --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
-                            --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                        docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
-                            --push .
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base
                     """
                 }
 

--- a/clamav/1.4/debian/Dockerfile
+++ b/clamav/1.4/debian/Dockerfile
@@ -91,7 +91,7 @@ RUN apt update && apt install -y \
         "/clamav/etc/clamav/clamav-milter.conf.sample" > "/clamav/etc/clamav/clamav-milter.conf" || \
     exit 1 \
     && \
-    ctest -V
+    ctest -V --timeout 3000
 
 FROM index.docker.io/library/debian:12-slim
 

--- a/clamav/1.4/debian/Jenkinsfile
+++ b/clamav/1.4/debian/Jenkinsfile
@@ -88,38 +88,58 @@ node('macos-newer') {
                 //
 
                 // Build X.Y.Z-R_base image.
+                sh """
+                    docker buildx build --no-cache --platform linux/amd64 \
+                        --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                        --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                        --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                        --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                        --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                        --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base-amd64 \
+                        --rm --push .
+
+                    docker buildx build --no-cache --platform linux/arm64 \
+                        --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                        --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                        --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                        --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                        --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                        --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base-arm64 \
+                        --rm --push .
+
+                    docker buildx build --no-cache --platform linux/ppc64le \
+                        --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                        --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                        --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                        --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                        --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                        --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base-ppc64le \
+                        --rm --push .
+
+                    docker buildx imagetools create -t ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                        "${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base-amd64" \
+                        "${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base-arm64" \
+                        "${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base-ppc64le"
+                """
 
                 if (params.IS_LATEST) {
                     // Create & Publish 'stable_base' and 'latest_base' tags.
                     sh """
-                        docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
-                            --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
-                            --annotation org.opencontainers.image.url=${params.REPOSITORY} \
-                            --annotation org.opencontainers.image.source=${params.REPOSITORY} \
-                            --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
-                            --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
-                            --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                        docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
-                            --push .
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base
                     """
                 }
                 else {
                     sh """
-                        docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
-                            --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
-                            --annotation org.opencontainers.image.url=${params.REPOSITORY} \
-                            --annotation org.opencontainers.image.source=${params.REPOSITORY} \
-                            --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
-                            --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
-                            --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
+                        docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}-${BUILD_NUMBER}_base \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
-                            --push .
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base
                     """
                 }
 

--- a/clamav/unstable/debian/Dockerfile
+++ b/clamav/unstable/debian/Dockerfile
@@ -91,7 +91,7 @@ RUN apt update && apt install -y \
         "/clamav/etc/clamav/clamav-milter.conf.sample" > "/clamav/etc/clamav/clamav-milter.conf" || \
     exit 1 \
     && \
-    ctest -V
+    ctest -V --timeout 3000
 
 FROM index.docker.io/library/debian:12-slim
 

--- a/clamav/unstable/debian/Jenkinsfile
+++ b/clamav/unstable/debian/Jenkinsfile
@@ -75,12 +75,40 @@ node('macos-newer') {
 
                 // Build 'unstable' and 'unstable_base' images.
                 sh """
-                docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
-                    --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
-                    --annotation org.opencontainers.image.url=${params.REPOSITORY} \
-                    --annotation org.opencontainers.image.source=${params.REPOSITORY} \
-                    --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
-                    --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base --push .
+                    docker buildx build --no-cache --platform linux/amd64 \
+                        --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                        --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                        --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                        --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                        --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                        --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base-amd64 \
+                        --rm --push .
+
+                    docker buildx build --no-cache --platform linux/arm64 \
+                        --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                        --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                        --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                        --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                        --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                        --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base-arm64 \
+                        --rm --push .
+
+                    docker buildx build --no-cache --platform linux/ppc64le \
+                        --sbom=true --provenance mode=max,builder-id=${BUILD_URL} \
+                        --annotation org.opencontainers.image.url=${params.REPOSITORY} \
+                        --annotation org.opencontainers.image.source=${params.REPOSITORY} \
+                        --annotation org.opencontainers.image.version=${params.FULL_VERSION} \
+                        --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
+                        --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base-ppc64le \
+                        --rm --push .
+
+                    docker buildx imagetools create -t ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base \
+                        "${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base-amd64" \
+                        "${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base-arm64" \
+                        "${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base-ppc64le"
                 """
 
                 // Give it some time to add the new unstable_base image.


### PR DESCRIPTION
Serialize the multi-arch build so it doesn't run out of RAM and die.

Increase the test timeout because I had to disable macOS Rosetta (x64 emulation under arm64) on the Docker host because it is buggy and occasionally fails for no good reason. Without Rosetta emulation, the default 1500sec CTest timeout is exceeded (at least for the `clamd` test on the `unstable` image). So I doubled the timeout to 3000sec. 