### PR TITLE
Remove duplicate line from Dockerfile 1.4 and 1.0 for alpine

### DIFF
--- a/clamav/1.0/alpine/Dockerfile
+++ b/clamav/1.0/alpine/Dockerfile
@@ -30,7 +30,6 @@ RUN apk update && apk upgrade \
         libmilter-dev \
         libxml2-dev \
         ncurses-dev \
-        ncurses-dev \
         openssl-dev \
         pcre2-dev \
         zlib-dev \

--- a/clamav/1.4/alpine/Dockerfile
+++ b/clamav/1.4/alpine/Dockerfile
@@ -30,7 +30,6 @@ RUN apk update && apk upgrade \
         libmilter-dev \
         libxml2-dev \
         ncurses-dev \
-        ncurses-dev \
         openssl-dev \
         pcre2-dev \
         zlib-dev \

--- a/clamav/unstable/alpine/Dockerfile
+++ b/clamav/unstable/alpine/Dockerfile
@@ -30,7 +30,6 @@ RUN apk update && apk upgrade \
         libmilter-dev \
         libxml2-dev \
         ncurses-dev \
-        ncurses-dev \
         openssl-dev \
         pcre2-dev \
         zlib-dev \


### PR DESCRIPTION
Duplicate line in apk-update in 
`# Clamav dependencies provided by alpine ` 
section was found.

The line `ncurses-dev \` is duplicated