### PR TITLE
Migrate multi-arch build away from macOS for stability

### DIFF
--- a/clamav/1.0/debian/Jenkinsfile
+++ b/clamav/1.0/debian/Jenkinsfile
@@ -19,7 +19,7 @@ properties([
         numToKeepStr: '20'))
 ])
 
-node('macos-newer') {
+node('docker-buildx') {
     cleanWs()
 
     try {
@@ -50,14 +50,6 @@ node('macos-newer') {
         """
 
         stage('Build Image') {
-            withVault([vaultSecrets: [[ path: "clamavbuild-kv/clamav_jenkins_svc_mac_minis", engineVersion: 1, secretValues:
-                        [[envVar: 'USER', vaultKey: 'username'],[envVar: 'PASSWORD', vaultKey: 'password']]]]]) {
-                // Enable keychain to access keystore, else docker will store credentials in plaintext
-                sh '''
-                security -v unlock-keychain -p "$PASSWORD" ~/Library/Keychains/login.keychain-db
-                security set-keychain-settings -t 36000 -l ~/Library/Keychains/login.keychain-db
-                '''
-            }
             withVault([vaultSecrets: [[ path: "clamavbuild-kv/${params.REGISTRY_CREDS}", engineVersion: 1, secretValues:
                         [[envVar: 'DOCKER_USER', vaultKey: 'username'],[envVar: 'DOCKER_PASSWD', vaultKey: 'password']]]]]) {
                 // Set docker buildx context

--- a/clamav/1.4/debian/Jenkinsfile
+++ b/clamav/1.4/debian/Jenkinsfile
@@ -19,7 +19,7 @@ properties([
         numToKeepStr: '20'))
 ])
 
-node('macos-newer') {
+node('docker-buildx') {
     cleanWs()
 
     try {
@@ -50,14 +50,6 @@ node('macos-newer') {
         """
 
         stage('Build Image') {
-            withVault([vaultSecrets: [[ path: "clamavbuild-kv/clamav_jenkins_svc_mac_minis", engineVersion: 1, secretValues:
-                        [[envVar: 'USER', vaultKey: 'username'],[envVar: 'PASSWORD', vaultKey: 'password']]]]]) {
-                // Enable keychain to access keystore, else docker will store credentials in plaintext
-                sh '''
-                security -v unlock-keychain -p "$PASSWORD" ~/Library/Keychains/login.keychain-db
-                security set-keychain-settings -t 36000 -l ~/Library/Keychains/login.keychain-db
-                '''
-            }
             withVault([vaultSecrets: [[ path: "clamavbuild-kv/${params.REGISTRY_CREDS}", engineVersion: 1, secretValues:
                         [[envVar: 'DOCKER_USER', vaultKey: 'username'],[envVar: 'DOCKER_PASSWD', vaultKey: 'password']]]]]) {
                 // Set docker buildx context

--- a/clamav/unstable/debian/Jenkinsfile
+++ b/clamav/unstable/debian/Jenkinsfile
@@ -15,7 +15,7 @@ properties([
         numToKeepStr: '20'))
 ])
 
-node('macos-newer') {
+node('docker-buildx') {
     cleanWs()
 
     try {
@@ -46,14 +46,6 @@ node('macos-newer') {
         """
 
         stage('Build Image') {
-            withVault([vaultSecrets: [[ path: "clamavbuild-kv/clamav_jenkins_svc_mac_minis", engineVersion: 1, secretValues:
-                        [[envVar: 'USER', vaultKey: 'username'],[envVar: 'PASSWORD', vaultKey: 'password']]]]]) {
-                // Enable keychain to access keystore, else docker will store credentials in plaintext
-                sh '''
-                security -v unlock-keychain -p "$PASSWORD" ~/Library/Keychains/login.keychain-db
-                security set-keychain-settings -t 36000 -l ~/Library/Keychains/login.keychain-db
-                '''
-            }
             withVault([vaultSecrets: [[ path: "clamavbuild-kv/${params.REGISTRY_CREDS}", engineVersion: 1, secretValues:
                         [[envVar: 'DOCKER_USER', vaultKey: 'username'],[envVar: 'DOCKER_PASSWD', vaultKey: 'password']]]]]) {
                 // Set docker buildx context


### PR DESCRIPTION
MacOS arm64 to amd64 builds are unstable and began to fail when calcualting SHA hashes on files greater than 4095-bytes in length. This is not a ClamAV bug, or even an OpenSSL bug as far as I can tell. The build and tests work fine using Docker buildx from Ubuntu.

CLAM-2855