### PR TITLE
CLAM-2970 - UID/GIU at runtime for privileged runs

### DIFF
--- a/clamav/1.0/alpine/Dockerfile
+++ b/clamav/1.0/alpine/Dockerfile
@@ -98,6 +98,7 @@ RUN apk update && apk upgrade \
     apk add \
         fts \
         libstdc++ \
+        shadow-utils \
         tini \
         tzdata \
         # Clamav dependencies provided by alpine
@@ -111,10 +112,11 @@ RUN apk update && apk upgrade \
         zlib \
     && \
     rm -rf /var/cache/apk/* && \
-    addgroup -S "clamav" && \
-    adduser -D -G "clamav" -h "/var/lib/clamav" -s "/bin/false" -u 100 -S "clamav" && \
-    install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
-    chown -R clamav:clamav /var/lib/clamav
+    groupadd -g 100 "clamav" && \
+    useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 100 -c "Clam Antivirus" clamav && \
+    install -d -m 755 -g 100 -o 100 "/var/log/clamav" && \
+    chown -R 100:100 /var/lib/clamav
+
 
 COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"

--- a/clamav/1.0/alpine/scripts/docker-entrypoint-unprivileged.sh
+++ b/clamav/1.0/alpine/scripts/docker-entrypoint-unprivileged.sh
@@ -10,6 +10,41 @@
 
 set -eu
 
+# ============================================================================
+# UID/GID Detection for Unprivileged Mode
+# ============================================================================
+# This script runs as non-root, so we cannot create/modify users
+# The clamav user must already exist (created by docker-entrypoint.sh or Dockerfile)
+# We detect the actual UID/GID from the existing user
+
+if ! id "clamav" > /dev/null 2>&1; then
+	echo "ERROR: clamav user does not exist!" >&2
+	echo "" >&2
+	echo "This unprivileged entrypoint requires the clamav user to already exist." >&2
+	echo "" >&2
+	echo "Solutions:" >&2
+	echo "  1. Use the privileged entrypoint (default):" >&2
+	echo "     docker run <image>" >&2
+	echo "" >&2
+	echo "  2. Use privileged entrypoint with custom UID/GID:" >&2
+	echo "     docker run -e CLAMAV_UID=2000 -e CLAMAV_GID=2000 <image>" >&2
+	echo "" >&2
+	echo "  3. Use unprivileged entrypoint after running privileged setup:" >&2
+	echo "     docker run --entrypoint /init <image>" >&2
+	exit 1
+fi
+
+# Get actual UID/GID from existing clamav user
+CLAMAV_UID=$(id -u clamav)
+CLAMAV_GID=$(id -g clamav)
+
+echo "INFO: Running as unprivileged user: clamav (UID=${CLAMAV_UID}, GID=${CLAMAV_GID})"
+
+# ============================================================================
+# End of UID/GID Detection
+# ============================================================================
+
+
 # run command if it is not starting with a "-" and is an executable in PATH
 if [ "${#}" -gt 0 ] && \
    [ "${1#-}" = "${1}" ] && \
@@ -43,7 +78,7 @@ else
 		          --daemon \
 		          --foreground \
 		          --stdout \
-		          --user="clamav" \
+		          --user="${CLAMAV_UID}" \
 			  &
 	fi
 

--- a/clamav/1.0/alpine/scripts/docker-entrypoint.sh
+++ b/clamav/1.0/alpine/scripts/docker-entrypoint.sh
@@ -10,12 +10,105 @@
 
 set -eu
 
+# ============================================================================
+# UID/GID Configuration Support
+# ============================================================================
+# Allow runtime override of UID/GID via environment variables
+# Default values match the Dockerfile (100 for Alpine)
+CLAMAV_UID="${CLAMAV_UID:-100}"
+CLAMAV_GID="${CLAMAV_GID:-100}"
+
+# Validation function for UID/GID
+validate_uid_gid() {
+	# Check if UID is numeric
+	if ! echo "${CLAMAV_UID}" | grep -qE '^[0-9]+$'; then
+		echo "ERROR: CLAMAV_UID must be numeric, got: ${CLAMAV_UID}" >&2
+		return 1
+	fi
+
+	# Check if GID is numeric
+	if ! echo "${CLAMAV_GID}" | grep -qE '^[0-9]+$'; then
+		echo "ERROR: CLAMAV_GID must be numeric, got: ${CLAMAV_GID}" >&2
+		return 1
+	fi
+
+	# Check UID is not 0 (root)
+	if [ "${CLAMAV_UID}" -eq 0 ]; then
+		echo "ERROR: CLAMAV_UID cannot be 0 (root)" >&2
+		return 1
+	fi
+
+	# Check GID is not 0 (root)
+	if [ "${CLAMAV_GID}" -eq 0 ]; then
+		echo "ERROR: CLAMAV_GID cannot be 0 (root)" >&2
+		return 1
+	fi
+
+	# Check UID/GID are within reasonable range
+	if [ "${CLAMAV_UID}" -gt 65535 ]; then
+		echo "WARNING: CLAMAV_UID ${CLAMAV_UID} is unusually high (> 65535)" >&2
+	fi
+
+	if [ "${CLAMAV_GID}" -gt 65535 ]; then
+		echo "WARNING: CLAMAV_GID ${CLAMAV_GID} is unusually high (> 65535)" >&2
+	fi
+
+	return 0
+}
+
+# Setup clamav user/group with custom UID/GID if needed
+setup_clamav_user() {
+	# Only modify if different from default (100)
+	if [ "${CLAMAV_UID}" != "100" ] || [ "${CLAMAV_GID}" != "100" ]; then
+		echo "INFO: Reconfiguring clamav user: UID=${CLAMAV_UID}, GID=${CLAMAV_GID}"
+
+		# Validate first
+		validate_uid_gid || return 1
+
+		# Modify user UID if needed
+		if [ "${CLAMAV_UID}" != "100" ]; then
+			usermod -u "${CLAMAV_UID}" clamav || {
+				echo "ERROR: Failed to set clamav user UID to ${CLAMAV_UID}" >&2
+				return 1
+			}
+		fi
+
+		# Modify group GID if needed
+		if [ "${CLAMAV_GID}" != "100" ]; then
+			groupmod -g "${CLAMAV_GID}" clamav || {
+				echo "ERROR: Failed to set clamav group GID to ${CLAMAV_GID}" >&2
+				return 1
+			}
+		fi
+
+		echo "INFO: Successfully reconfigured clamav user with UID=${CLAMAV_UID}, GID=${CLAMAV_GID}"
+	else
+		echo "INFO: Using default clamav user: UID=100, GID=100"
+	fi
+}
+
+# Call setup function
+setup_clamav_user || exit 1
+
+# ============================================================================
+# End of UID/GID Configuration
+# ============================================================================
+
+
 if [ ! -d "/run/clamav" ]; then
-	install -d -g "clamav" -m 775 -o "clamav" "/run/clamav"
+	echo "INFO: Creating /run/clamav directory"
+	install -d -g "${CLAMAV_GID}" -m 775 -o "${CLAMAV_UID}" "/run/clamav"
+else
+	echo "INFO: Fixing ownership of /run/clamav directory"
+	chown "${CLAMAV_UID}:${CLAMAV_GID}" "/run/clamav"
+	chmod 775 "/run/clamav"
 fi
 
-# Assign ownership to the database directory, just in case it is a mounted volume
-chown -R clamav:clamav /var/lib/clamav
+# Ensure /var/log/clamav exists before chowning
+if [ ! -d "/var/log/clamav" ]; then
+    install -d -m 755 -g "${CLAMAV_GID}" -o "${CLAMAV_UID}" "/var/log/clamav"
+fi
+chown -R "${CLAMAV_UID}:${CLAMAV_GID}" /var/lib/clamav /var/log/clamav
 
 # configure freshclam.conf and clamd.conf from env variables if present
 env | grep "^CLAMD_CONF_" | while IFS="=" read -r KEY VALUE; do
@@ -71,7 +164,7 @@ else
 		          --daemon \
 		          --foreground \
 		          --stdout \
-		          --user="clamav" \
+		          --user="${CLAMAV_UID}" \
 			  &
 	fi
 

--- a/clamav/1.0/debian/Dockerfile
+++ b/clamav/1.0/debian/Dockerfile
@@ -121,8 +121,8 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/cache/apt/archives && \
     groupadd -g 1000 "clamav" && \
     useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 1000 -c "Clam Antivirus" clamav && \
-    install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
-    chown -R clamav:clamav /var/lib/clamav
+    install -d -m 755 -g 1000 -o 1000 "/var/log/clamav" && \
+    chown -R 1000:1000 /var/lib/clamav
 
 COPY --from=builder "/clamav" "/"
 

--- a/clamav/1.0/debian/scripts/docker-entrypoint-unprivileged.sh
+++ b/clamav/1.0/debian/scripts/docker-entrypoint-unprivileged.sh
@@ -10,6 +10,41 @@
 
 set -eu
 
+# ============================================================================
+# UID/GID Detection for Unprivileged Mode
+# ============================================================================
+# This script runs as non-root, so we cannot create/modify users
+# The clamav user must already exist (created by docker-entrypoint.sh or Dockerfile)
+# We detect the actual UID/GID from the existing user
+
+if ! id "clamav" > /dev/null 2>&1; then
+	echo "ERROR: clamav user does not exist!" >&2
+	echo "" >&2
+	echo "This unprivileged entrypoint requires the clamav user to already exist." >&2
+	echo "" >&2
+	echo "Solutions:" >&2
+	echo "  1. Use the privileged entrypoint (default):" >&2
+	echo "     docker run <image>" >&2
+	echo "" >&2
+	echo "  2. Use privileged entrypoint with custom UID/GID:" >&2
+	echo "     docker run -e CLAMAV_UID=2000 -e CLAMAV_GID=2000 <image>" >&2
+	echo "" >&2
+	echo "  3. Use unprivileged entrypoint after running privileged setup:" >&2
+	echo "     docker run --entrypoint /init <image>" >&2
+	exit 1
+fi
+
+# Get actual UID/GID from existing clamav user
+CLAMAV_UID=$(id -u clamav)
+CLAMAV_GID=$(id -g clamav)
+
+echo "INFO: Running as unprivileged user: clamav (UID=${CLAMAV_UID}, GID=${CLAMAV_GID})"
+
+# ============================================================================
+# End of UID/GID Detection
+# ============================================================================
+
+
 # run command if it is not starting with a "-" and is an executable in PATH
 if [ "${#}" -gt 0 ] && \
    [ "${1#-}" = "${1}" ] && \
@@ -43,7 +78,7 @@ else
 		          --daemon \
 		          --foreground \
 		          --stdout \
-		          --user="clamav" \
+		          --user="${CLAMAV_UID}" \
 			  &
 	fi
 

--- a/clamav/1.0/debian/scripts/docker-entrypoint.sh
+++ b/clamav/1.0/debian/scripts/docker-entrypoint.sh
@@ -10,12 +10,105 @@
 
 set -eu
 
+# ============================================================================
+# UID/GID Configuration Support
+# ============================================================================
+# Allow runtime override of UID/GID via environment variables
+# Default values match the Dockerfile (1000 for Debian)
+CLAMAV_UID="${CLAMAV_UID:-1000}"
+CLAMAV_GID="${CLAMAV_GID:-1000}"
+
+# Validation function for UID/GID
+validate_uid_gid() {
+	# Check if UID is numeric
+	if ! echo "${CLAMAV_UID}" | grep -qE '^[0-9]+$'; then
+		echo "ERROR: CLAMAV_UID must be numeric, got: ${CLAMAV_UID}" >&2
+		return 1
+	fi
+
+	# Check if GID is numeric
+	if ! echo "${CLAMAV_GID}" | grep -qE '^[0-9]+$'; then
+		echo "ERROR: CLAMAV_GID must be numeric, got: ${CLAMAV_GID}" >&2
+		return 1
+	fi
+
+	# Check UID is not 0 (root)
+	if [ "${CLAMAV_UID}" -eq 0 ]; then
+		echo "ERROR: CLAMAV_UID cannot be 0 (root)" >&2
+		return 1
+	fi
+
+	# Check GID is not 0 (root)
+	if [ "${CLAMAV_GID}" -eq 0 ]; then
+		echo "ERROR: CLAMAV_GID cannot be 0 (root)" >&2
+		return 1
+	fi
+
+	# Check UID/GID are within reasonable range
+	if [ "${CLAMAV_UID}" -gt 65535 ]; then
+		echo "WARNING: CLAMAV_UID ${CLAMAV_UID} is unusually high (> 65535)" >&2
+	fi
+
+	if [ "${CLAMAV_GID}" -gt 65535 ]; then
+		echo "WARNING: CLAMAV_GID ${CLAMAV_GID} is unusually high (> 65535)" >&2
+	fi
+
+	return 0
+}
+
+# Setup clamav user/group with custom UID/GID if needed
+setup_clamav_user() {
+	# Only modify if different from default (1000)
+	if [ "${CLAMAV_UID}" != "1000" ] || [ "${CLAMAV_GID}" != "1000" ]; then
+		echo "INFO: Reconfiguring clamav user: UID=${CLAMAV_UID}, GID=${CLAMAV_GID}"
+
+		# Validate first
+		validate_uid_gid || return 1
+
+		# Modify user UID if needed
+		if [ "${CLAMAV_UID}" != "1000" ]; then
+			usermod -u "${CLAMAV_UID}" clamav || {
+				echo "ERROR: Failed to set clamav user UID to ${CLAMAV_UID}" >&2
+				return 1
+			}
+		fi
+
+		# Modify group GID if needed
+		if [ "${CLAMAV_GID}" != "1000" ]; then
+			groupmod -g "${CLAMAV_GID}" clamav || {
+				echo "ERROR: Failed to set clamav group GID to ${CLAMAV_GID}" >&2
+				return 1
+			}
+		fi
+
+		echo "INFO: Successfully reconfigured clamav user with UID=${CLAMAV_UID}, GID=${CLAMAV_GID}"
+	else
+		echo "INFO: Using default clamav user: UID=1000, GID=1000"
+	fi
+}
+
+# Call setup function
+setup_clamav_user || exit 1
+
+# ============================================================================
+# End of UID/GID Configuration
+# ============================================================================
+
+
 if [ ! -d "/run/clamav" ]; then
-	install -d -g "clamav" -m 775 -o "clamav" "/run/clamav"
+	echo "INFO: Creating /run/clamav directory"
+	install -d -g "${CLAMAV_GID}" -m 775 -o "${CLAMAV_UID}" "/run/clamav"
+else
+	echo "INFO: Fixing ownership of /run/clamav directory"
+	chown "${CLAMAV_UID}:${CLAMAV_GID}" "/run/clamav"
+	chmod 775 "/run/clamav"
 fi
 
-# Assign ownership to the database directory, just in case it is a mounted volume
-chown -R clamav:clamav /var/lib/clamav
+# Ensure /var/log/clamav exists before chowning
+if [ ! -d "/var/log/clamav" ]; then
+    install -d -m 755 -g "${CLAMAV_GID}" -o "${CLAMAV_UID}" "/var/log/clamav"
+fi
+chown -R "${CLAMAV_UID}:${CLAMAV_GID}" /var/lib/clamav /var/log/clamav
 
 # configure freshclam.conf and clamd.conf from env variables if present
 env | grep "^CLAMD_CONF_" | while IFS="=" read -r KEY VALUE; do
@@ -71,7 +164,7 @@ else
 		          --daemon \
 		          --foreground \
 		          --stdout \
-		          --user="clamav" \
+		          --user="${CLAMAV_UID}" \
 			  &
 	fi
 

--- a/clamav/1.4/alpine/Dockerfile
+++ b/clamav/1.4/alpine/Dockerfile
@@ -98,6 +98,7 @@ RUN apk update && apk upgrade \
     apk add \
         fts \
         libstdc++ \
+        shadow-utils \
         tini \
         tzdata \
         # Clamav dependencies provided by alpine
@@ -111,10 +112,11 @@ RUN apk update && apk upgrade \
         zlib \
     && \
     rm -rf /var/cache/apk/* && \
-    addgroup -S "clamav" && \
-    adduser -D -G "clamav" -h "/var/lib/clamav" -s "/bin/false" -u 100 -S "clamav" && \
-    install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
-    chown -R clamav:clamav /var/lib/clamav
+    groupadd -g 100 "clamav" && \
+    useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 100 -c "Clam Antivirus" clamav && \
+    install -d -m 755 -g 100 -o 100 "/var/log/clamav" && \
+    chown -R 100:100 /var/lib/clamav
+
 
 COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"

--- a/clamav/1.4/alpine/scripts/docker-entrypoint-unprivileged.sh
+++ b/clamav/1.4/alpine/scripts/docker-entrypoint-unprivileged.sh
@@ -10,6 +10,41 @@
 
 set -eu
 
+# ============================================================================
+# UID/GID Detection for Unprivileged Mode
+# ============================================================================
+# This script runs as non-root, so we cannot create/modify users
+# The clamav user must already exist (created by docker-entrypoint.sh or Dockerfile)
+# We detect the actual UID/GID from the existing user
+
+if ! id "clamav" > /dev/null 2>&1; then
+	echo "ERROR: clamav user does not exist!" >&2
+	echo "" >&2
+	echo "This unprivileged entrypoint requires the clamav user to already exist." >&2
+	echo "" >&2
+	echo "Solutions:" >&2
+	echo "  1. Use the privileged entrypoint (default):" >&2
+	echo "     docker run <image>" >&2
+	echo "" >&2
+	echo "  2. Use privileged entrypoint with custom UID/GID:" >&2
+	echo "     docker run -e CLAMAV_UID=2000 -e CLAMAV_GID=2000 <image>" >&2
+	echo "" >&2
+	echo "  3. Use unprivileged entrypoint after running privileged setup:" >&2
+	echo "     docker run --entrypoint /init <image>" >&2
+	exit 1
+fi
+
+# Get actual UID/GID from existing clamav user
+CLAMAV_UID=$(id -u clamav)
+CLAMAV_GID=$(id -g clamav)
+
+echo "INFO: Running as unprivileged user: clamav (UID=${CLAMAV_UID}, GID=${CLAMAV_GID})"
+
+# ============================================================================
+# End of UID/GID Detection
+# ============================================================================
+
+
 # run command if it is not starting with a "-" and is an executable in PATH
 if [ "${#}" -gt 0 ] && \
    [ "${1#-}" = "${1}" ] && \
@@ -43,7 +78,7 @@ else
 		          --daemon \
 		          --foreground \
 		          --stdout \
-		          --user="clamav" \
+		          --user="${CLAMAV_UID}" \
 			  &
 	fi
 

--- a/clamav/1.4/alpine/scripts/docker-entrypoint.sh
+++ b/clamav/1.4/alpine/scripts/docker-entrypoint.sh
@@ -10,12 +10,105 @@
 
 set -eu
 
+# ============================================================================
+# UID/GID Configuration Support
+# ============================================================================
+# Allow runtime override of UID/GID via environment variables
+# Default values match the Dockerfile (100 for Alpine)
+CLAMAV_UID="${CLAMAV_UID:-100}"
+CLAMAV_GID="${CLAMAV_GID:-100}"
+
+# Validation function for UID/GID
+validate_uid_gid() {
+	# Check if UID is numeric
+	if ! echo "${CLAMAV_UID}" | grep -qE '^[0-9]+$'; then
+		echo "ERROR: CLAMAV_UID must be numeric, got: ${CLAMAV_UID}" >&2
+		return 1
+	fi
+
+	# Check if GID is numeric
+	if ! echo "${CLAMAV_GID}" | grep -qE '^[0-9]+$'; then
+		echo "ERROR: CLAMAV_GID must be numeric, got: ${CLAMAV_GID}" >&2
+		return 1
+	fi
+
+	# Check UID is not 0 (root)
+	if [ "${CLAMAV_UID}" -eq 0 ]; then
+		echo "ERROR: CLAMAV_UID cannot be 0 (root)" >&2
+		return 1
+	fi
+
+	# Check GID is not 0 (root)
+	if [ "${CLAMAV_GID}" -eq 0 ]; then
+		echo "ERROR: CLAMAV_GID cannot be 0 (root)" >&2
+		return 1
+	fi
+
+	# Check UID/GID are within reasonable range
+	if [ "${CLAMAV_UID}" -gt 65535 ]; then
+		echo "WARNING: CLAMAV_UID ${CLAMAV_UID} is unusually high (> 65535)" >&2
+	fi
+
+	if [ "${CLAMAV_GID}" -gt 65535 ]; then
+		echo "WARNING: CLAMAV_GID ${CLAMAV_GID} is unusually high (> 65535)" >&2
+	fi
+
+	return 0
+}
+
+# Setup clamav user/group with custom UID/GID if needed
+setup_clamav_user() {
+	# Only modify if different from default (100)
+	if [ "${CLAMAV_UID}" != "100" ] || [ "${CLAMAV_GID}" != "100" ]; then
+		echo "INFO: Reconfiguring clamav user: UID=${CLAMAV_UID}, GID=${CLAMAV_GID}"
+
+		# Validate first
+		validate_uid_gid || return 1
+
+		# Modify user UID if needed
+		if [ "${CLAMAV_UID}" != "100" ]; then
+			usermod -u "${CLAMAV_UID}" clamav || {
+				echo "ERROR: Failed to set clamav user UID to ${CLAMAV_UID}" >&2
+				return 1
+			}
+		fi
+
+		# Modify group GID if needed
+		if [ "${CLAMAV_GID}" != "100" ]; then
+			groupmod -g "${CLAMAV_GID}" clamav || {
+				echo "ERROR: Failed to set clamav group GID to ${CLAMAV_GID}" >&2
+				return 1
+			}
+		fi
+
+		echo "INFO: Successfully reconfigured clamav user with UID=${CLAMAV_UID}, GID=${CLAMAV_GID}"
+	else
+		echo "INFO: Using default clamav user: UID=100, GID=100"
+	fi
+}
+
+# Call setup function
+setup_clamav_user || exit 1
+
+# ============================================================================
+# End of UID/GID Configuration
+# ============================================================================
+
+
 if [ ! -d "/run/clamav" ]; then
-	install -d -g "clamav" -m 775 -o "clamav" "/run/clamav"
+	echo "INFO: Creating /run/clamav directory"
+	install -d -g "${CLAMAV_GID}" -m 775 -o "${CLAMAV_UID}" "/run/clamav"
+else
+	echo "INFO: Fixing ownership of /run/clamav directory"
+	chown "${CLAMAV_UID}:${CLAMAV_GID}" "/run/clamav"
+	chmod 775 "/run/clamav"
 fi
 
-# Assign ownership to the database directory, just in case it is a mounted volume
-chown -R clamav:clamav /var/lib/clamav
+# Ensure /var/log/clamav exists before chowning
+if [ ! -d "/var/log/clamav" ]; then
+    install -d -m 755 -g "${CLAMAV_GID}" -o "${CLAMAV_UID}" "/var/log/clamav"
+fi
+chown -R "${CLAMAV_UID}:${CLAMAV_GID}" /var/lib/clamav /var/log/clamav
 
 # configure freshclam.conf and clamd.conf from env variables if present
 env | grep "^CLAMD_CONF_" | while IFS="=" read -r KEY VALUE; do
@@ -71,7 +164,7 @@ else
 		          --daemon \
 		          --foreground \
 		          --stdout \
-		          --user="clamav" \
+		          --user="${CLAMAV_UID}" \
 			  &
 	fi
 

--- a/clamav/1.4/debian/Dockerfile
+++ b/clamav/1.4/debian/Dockerfile
@@ -121,8 +121,8 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/cache/apt/archives && \
     groupadd -g 1000 "clamav" && \
     useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 1000 -c "Clam Antivirus" clamav && \
-    install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
-    chown -R clamav:clamav /var/lib/clamav
+    install -d -m 755 -g 1000 -o 1000 "/var/log/clamav" && \
+    chown -R 1000:1000 /var/lib/clamav
 
 COPY --from=builder "/clamav" "/"
 

--- a/clamav/1.4/debian/scripts/docker-entrypoint-unprivileged.sh
+++ b/clamav/1.4/debian/scripts/docker-entrypoint-unprivileged.sh
@@ -10,6 +10,41 @@
 
 set -eu
 
+# ============================================================================
+# UID/GID Detection for Unprivileged Mode
+# ============================================================================
+# This script runs as non-root, so we cannot create/modify users
+# The clamav user must already exist (created by docker-entrypoint.sh or Dockerfile)
+# We detect the actual UID/GID from the existing user
+
+if ! id "clamav" > /dev/null 2>&1; then
+	echo "ERROR: clamav user does not exist!" >&2
+	echo "" >&2
+	echo "This unprivileged entrypoint requires the clamav user to already exist." >&2
+	echo "" >&2
+	echo "Solutions:" >&2
+	echo "  1. Use the privileged entrypoint (default):" >&2
+	echo "     docker run <image>" >&2
+	echo "" >&2
+	echo "  2. Use privileged entrypoint with custom UID/GID:" >&2
+	echo "     docker run -e CLAMAV_UID=2000 -e CLAMAV_GID=2000 <image>" >&2
+	echo "" >&2
+	echo "  3. Use unprivileged entrypoint after running privileged setup:" >&2
+	echo "     docker run --entrypoint /init <image>" >&2
+	exit 1
+fi
+
+# Get actual UID/GID from existing clamav user
+CLAMAV_UID=$(id -u clamav)
+CLAMAV_GID=$(id -g clamav)
+
+echo "INFO: Running as unprivileged user: clamav (UID=${CLAMAV_UID}, GID=${CLAMAV_GID})"
+
+# ============================================================================
+# End of UID/GID Detection
+# ============================================================================
+
+
 # run command if it is not starting with a "-" and is an executable in PATH
 if [ "${#}" -gt 0 ] && \
    [ "${1#-}" = "${1}" ] && \
@@ -43,7 +78,7 @@ else
 		          --daemon \
 		          --foreground \
 		          --stdout \
-		          --user="clamav" \
+		          --user="${CLAMAV_UID}" \
 			  &
 	fi
 

--- a/clamav/1.4/debian/scripts/docker-entrypoint.sh
+++ b/clamav/1.4/debian/scripts/docker-entrypoint.sh
@@ -10,12 +10,105 @@
 
 set -eu
 
+# ============================================================================
+# UID/GID Configuration Support
+# ============================================================================
+# Allow runtime override of UID/GID via environment variables
+# Default values match the Dockerfile (1000 for Debian)
+CLAMAV_UID="${CLAMAV_UID:-1000}"
+CLAMAV_GID="${CLAMAV_GID:-1000}"
+
+# Validation function for UID/GID
+validate_uid_gid() {
+	# Check if UID is numeric
+	if ! echo "${CLAMAV_UID}" | grep -qE '^[0-9]+$'; then
+		echo "ERROR: CLAMAV_UID must be numeric, got: ${CLAMAV_UID}" >&2
+		return 1
+	fi
+
+	# Check if GID is numeric
+	if ! echo "${CLAMAV_GID}" | grep -qE '^[0-9]+$'; then
+		echo "ERROR: CLAMAV_GID must be numeric, got: ${CLAMAV_GID}" >&2
+		return 1
+	fi
+
+	# Check UID is not 0 (root)
+	if [ "${CLAMAV_UID}" -eq 0 ]; then
+		echo "ERROR: CLAMAV_UID cannot be 0 (root)" >&2
+		return 1
+	fi
+
+	# Check GID is not 0 (root)
+	if [ "${CLAMAV_GID}" -eq 0 ]; then
+		echo "ERROR: CLAMAV_GID cannot be 0 (root)" >&2
+		return 1
+	fi
+
+	# Check UID/GID are within reasonable range
+	if [ "${CLAMAV_UID}" -gt 65535 ]; then
+		echo "WARNING: CLAMAV_UID ${CLAMAV_UID} is unusually high (> 65535)" >&2
+	fi
+
+	if [ "${CLAMAV_GID}" -gt 65535 ]; then
+		echo "WARNING: CLAMAV_GID ${CLAMAV_GID} is unusually high (> 65535)" >&2
+	fi
+
+	return 0
+}
+
+# Setup clamav user/group with custom UID/GID if needed
+setup_clamav_user() {
+	# Only modify if different from default (1000)
+	if [ "${CLAMAV_UID}" != "1000" ] || [ "${CLAMAV_GID}" != "1000" ]; then
+		echo "INFO: Reconfiguring clamav user: UID=${CLAMAV_UID}, GID=${CLAMAV_GID}"
+
+		# Validate first
+		validate_uid_gid || return 1
+
+		# Modify user UID if needed
+		if [ "${CLAMAV_UID}" != "1000" ]; then
+			usermod -u "${CLAMAV_UID}" clamav || {
+				echo "ERROR: Failed to set clamav user UID to ${CLAMAV_UID}" >&2
+				return 1
+			}
+		fi
+
+		# Modify group GID if needed
+		if [ "${CLAMAV_GID}" != "1000" ]; then
+			groupmod -g "${CLAMAV_GID}" clamav || {
+				echo "ERROR: Failed to set clamav group GID to ${CLAMAV_GID}" >&2
+				return 1
+			}
+		fi
+
+		echo "INFO: Successfully reconfigured clamav user with UID=${CLAMAV_UID}, GID=${CLAMAV_GID}"
+	else
+		echo "INFO: Using default clamav user: UID=1000, GID=1000"
+	fi
+}
+
+# Call setup function
+setup_clamav_user || exit 1
+
+# ============================================================================
+# End of UID/GID Configuration
+# ============================================================================
+
+
 if [ ! -d "/run/clamav" ]; then
-	install -d -g "clamav" -m 775 -o "clamav" "/run/clamav"
+	echo "INFO: Creating /run/clamav directory"
+	install -d -g "${CLAMAV_GID}" -m 775 -o "${CLAMAV_UID}" "/run/clamav"
+else
+	echo "INFO: Fixing ownership of /run/clamav directory"
+	chown "${CLAMAV_UID}:${CLAMAV_GID}" "/run/clamav"
+	chmod 775 "/run/clamav"
 fi
 
-# Assign ownership to the database directory, just in case it is a mounted volume
-chown -R clamav:clamav /var/lib/clamav
+# Ensure /var/log/clamav exists before chowning
+if [ ! -d "/var/log/clamav" ]; then
+    install -d -m 755 -g "${CLAMAV_GID}" -o "${CLAMAV_UID}" "/var/log/clamav"
+fi
+chown -R "${CLAMAV_UID}:${CLAMAV_GID}" /var/lib/clamav /var/log/clamav
 
 # configure freshclam.conf and clamd.conf from env variables if present
 env | grep "^CLAMD_CONF_" | while IFS="=" read -r KEY VALUE; do
@@ -71,7 +164,7 @@ else
 		          --daemon \
 		          --foreground \
 		          --stdout \
-		          --user="clamav" \
+		          --user="${CLAMAV_UID}" \
 			  &
 	fi
 

--- a/clamav/1.5/alpine/Dockerfile
+++ b/clamav/1.5/alpine/Dockerfile
@@ -98,6 +98,7 @@ RUN apk update && apk upgrade \
     apk add \
         fts \
         libstdc++ \
+        shadow-utils \
         tini \
         tzdata \
         # Clamav dependencies provided by alpine
@@ -111,10 +112,11 @@ RUN apk update && apk upgrade \
         zlib \
     && \
     rm -rf /var/cache/apk/* && \
-    addgroup -S "clamav" && \
-    adduser -D -G "clamav" -h "/var/lib/clamav" -s "/bin/false" -u 100 -S "clamav" && \
-    install -d -m 755 -g "clamav" -o "clamav" "/var/log/clamav" && \
-    chown -R clamav:clamav /var/lib/clamav
+    groupadd -g 100 "clamav" && \
+    useradd -m -g clamav -s /bin/false --home-dir /var/lib/clamav -u 100 -c "Clam Antivirus" clamav && \
+    install -d -m 755 -g 100 -o 100 "/var/log/clamav" && \
+    chown -R 100:100 /var/lib/clamav
+
 
 COPY --from=builder "/clamav" "/"
 COPY "./scripts/clamdcheck.sh" "/usr/local/bin/"

--- a/clamav/1.5/alpine/scripts/docker-entrypoint-unprivileged.sh
+++ b/clamav/1.5/alpine/scripts/docker-entrypoint-unprivileged.sh
@@ -10,6 +10,41 @@
 
 set -eu
 
+# ============================================================================
+# UID/GID Detection for Unprivileged Mode
+# ============================================================================
+# This script runs as non-root, so we cannot create/modify users
+# The clamav user must already exist (created by docker-entrypoint.sh or Dockerfile)
+# We detect the actual UID/GID from the existing user
+
+if ! id "clamav" > /dev/null 2>&1; then
+	echo "ERROR: clamav user does not exist!" >&2
+	echo "" >&2
+	echo "This unprivileged entrypoint requires the clamav user to already exist." >&2
+	echo "" >&2
+	echo "Solutions:" >&2
+	echo "  1. Use the privileged entrypoint (default):" >&2
+	echo "     docker run <image>" >&2
+	echo "" >&2
+	echo "  2. Use privileged entrypoint with custom UID/GID:" >&2
+	echo "     docker run -e CLAMAV_UID=2000 -e CLAMAV_GID=2000 <image>" >&2
+	echo "" >&2
+	echo "  3. Use unprivileged entrypoint after running privileged setup:" >&2
+	echo "     docker run --entrypoint /init <image>" >&2
+	exit 1
+fi
+
+# Get actual UID/GID from existing clamav user
+CLAMAV_UID=$(id -u clamav)
+CLAMAV_GID=$(id -g clamav)
+
+echo "INFO: Running as unprivileged user: clamav (UID=${CLAMAV_UID}, GID=${CLAMAV_GID})"
+
+# ============================================================================
+# End of UID/GID Detection
+# ============================================================================
+
+
 # run command if it is not starting with a "-" and is an executable in PATH
 if [ "${#}" -gt 0 ] && \
    [ "${1#-}" = "${1}" ] && \
@@ -43,7 +78,7 @@ else
 		          --daemon \
 		          --foreground \
 		          --stdout \
-		          --user="clamav" \
+		          --user="${CLAMAV_UID}" \
 			  &
 	fi
 

--- a/clamav/1.5/alpine/scripts/docker-entrypoint.sh
+++ b/clamav/1.5/alpine/scripts/docker-entrypoint.sh
@@ -10,12 +10,105 @@
 
 set -eu
 
+# ============================================================================
+# UID/GID Configuration Support
+# ============================================================================
+# Allow runtime override of UID/GID via environment variables
+# Default values match the Dockerfile (100 for Alpine)
+CLAMAV_UID="${CLAMAV_UID:-100}"
+CLAMAV_GID="${CLAMAV_GID:-100}"
+
+# Validation function for UID/GID
+validate_uid_gid() {
+	# Check if UID is numeric
+	if ! echo "${CLAMAV_UID}" | grep -qE '^[0-9]+$'; then
+		echo "ERROR: CLAMAV_UID must be numeric, got: ${CLAMAV_UID}" >&2
+		return 1
+	fi
+
+	# Check if GID is numeric
+	if ! echo "${CLAMAV_GID}" | grep -qE '^[0-9]+$'; then
+		echo "ERROR: CLAMAV_GID must be numeric, got: ${CLAMAV_GID}" >&2
+		return 1
+	fi
+
+	# Check UID is not 0 (root)
+	if [ "${CLAMAV_UID}" -eq 0 ]; then
+		echo "ERROR: CLAMAV_UID cannot be 0 (root)" >&2
+		return 1
+	fi
+
+	# Check GID is not 0 (root)
+	if [ "${CLAMAV_GID}" -eq 0 ]; then
+		echo "ERROR: CLAMAV_GID cannot be 0 (root)" >&2
+		return 1
+	fi
+
+	# Check UID/GID are within reasonable range
+	if [ "${CLAMAV_UID}" -gt 65535 ]; then
+		echo "WARNING: CLAMAV_UID ${CLAMAV_UID} is unusually high (> 65535)" >&2
+	fi
+
+	if [ "${CLAMAV_GID}" -gt 65535 ]; then
+		echo "WARNING: CLAMAV_GID ${CLAMAV_GID} is unusually high (> 65535)" >&2
+	fi
+
+	return 0
+}
+
+# Setup clamav user/group with custom UID/GID if needed
+setup_clamav_user() {
+	# Only modify if different from default (100)
+	if [ "${CLAMAV_UID}" != "100" ] || [ "${CLAMAV_GID}" != "100" ]; then
+		echo "INFO: Reconfiguring clamav user: UID=${CLAMAV_UID}, GID=${CLAMAV_GID}"
+
+		# Validate first
+		validate_uid_gid || return 1
+
+		# Modify user UID if needed
+		if [ "${CLAMAV_UID}" != "100" ]; then
+			usermod -u "${CLAMAV_UID}" clamav || {
+				echo "ERROR: Failed to set clamav user UID to ${CLAMAV_UID}" >&2
+				return 1
+			}
+		fi
+
+		# Modify group GID if needed
+		if [ "${CLAMAV_GID}" != "100" ]; then
+			groupmod -g "${CLAMAV_GID}" clamav || {
+				echo "ERROR: Failed to set clamav group GID to ${CLAMAV_GID}" >&2
+				return 1
+			}
+		fi
+
+		echo "INFO: Successfully reconfigured clamav user with UID=${CLAMAV_UID}, GID=${CLAMAV_GID}"
+	else
+		echo "INFO: Using default clamav user: UID=100, GID=100"
+	fi
+}
+
+# Call setup function
+setup_clamav_user || exit 1
+
+# ============================================================================
+# End of UID/GID Configuration
+# ============================================================================
+
+
 if [ ! -d "/run/clamav" ]; then
-	install -d -g "clamav" -m 775 -o "clamav" "/run/clamav"
+	echo "INFO: Creating /run/clamav directory"
+	install -d -g "${CLAMAV_GID}" -m 775 -o "${CLAMAV_UID}" "/run/clamav"
+else
+	echo "INFO: Fixing ownership of /run/clamav directory"
+	chown "${CLAMAV_UID}:${CLAMAV_GID}" "/run/clamav"
+	chmod 775 "/run/clamav"
 fi
 
-# Assign ownership to the database directory, just in case it is a mounted volume
-chown -R clamav:clamav /var/lib/clamav
+# Ensure /var/log/clamav exists before chowning
+if [ ! -d "/var/log/clamav" ]; then
+    install -d -m 755 -g "${CLAMAV_GID}" -o "${CLAMAV_UID}" "/var/log/clamav"
+fi
+chown -R "${CLAMAV_UID}:${CLAMAV_GID}" /var/lib/clamav /var/log/clamav
 
 # configure freshclam.conf and clamd.conf from env variables if present
 env | grep "^CLAMD_CONF_" | while IFS="=" read -r KEY VALUE; do
@@ -71,7 +164,7 @@ else
 		          --daemon \
 		          --foreground \
 		          --stdout \
-		          --user="clamav" \
+		          --user="${CLAMAV_UID}" \
 			  &
 	fi
 

--- a/clamav/1.5/debian/scripts/docker-entrypoint-unprivileged.sh
+++ b/clamav/1.5/debian/scripts/docker-entrypoint-unprivileged.sh
@@ -10,6 +10,41 @@
 
 set -eu
 
+# ============================================================================
+# UID/GID Detection for Unprivileged Mode
+# ============================================================================
+# This script runs as non-root, so we cannot create/modify users
+# The clamav user must already exist (created by docker-entrypoint.sh or Dockerfile)
+# We detect the actual UID/GID from the existing user
+
+if ! id "clamav" > /dev/null 2>&1; then
+	echo "ERROR: clamav user does not exist!" >&2
+	echo "" >&2
+	echo "This unprivileged entrypoint requires the clamav user to already exist." >&2
+	echo "" >&2
+	echo "Solutions:" >&2
+	echo "  1. Use the privileged entrypoint (default):" >&2
+	echo "     docker run <image>" >&2
+	echo "" >&2
+	echo "  2. Use privileged entrypoint with custom UID/GID:" >&2
+	echo "     docker run -e CLAMAV_UID=2000 -e CLAMAV_GID=2000 <image>" >&2
+	echo "" >&2
+	echo "  3. Use unprivileged entrypoint after running privileged setup:" >&2
+	echo "     docker run --entrypoint /init <image>" >&2
+	exit 1
+fi
+
+# Get actual UID/GID from existing clamav user
+CLAMAV_UID=$(id -u clamav)
+CLAMAV_GID=$(id -g clamav)
+
+echo "INFO: Running as unprivileged user: clamav (UID=${CLAMAV_UID}, GID=${CLAMAV_GID})"
+
+# ============================================================================
+# End of UID/GID Detection
+# ============================================================================
+
+
 # run command if it is not starting with a "-" and is an executable in PATH
 if [ "${#}" -gt 0 ] && \
    [ "${1#-}" = "${1}" ] && \
@@ -43,7 +78,7 @@ else
 		          --daemon \
 		          --foreground \
 		          --stdout \
-		          --user="clamav" \
+		          --user="${CLAMAV_UID}" \
 			  &
 	fi
 

--- a/clamav/1.5/debian/scripts/docker-entrypoint.sh
+++ b/clamav/1.5/debian/scripts/docker-entrypoint.sh
@@ -10,12 +10,105 @@
 
 set -eu
 
+# ============================================================================
+# UID/GID Configuration Support
+# ============================================================================
+# Allow runtime override of UID/GID via environment variables
+# Default values match the Dockerfile (1000 for Debian)
+CLAMAV_UID="${CLAMAV_UID:-1000}"
+CLAMAV_GID="${CLAMAV_GID:-1000}"
+
+# Validation function for UID/GID
+validate_uid_gid() {
+	# Check if UID is numeric
+	if ! echo "${CLAMAV_UID}" | grep -qE '^[0-9]+$'; then
+		echo "ERROR: CLAMAV_UID must be numeric, got: ${CLAMAV_UID}" >&2
+		return 1
+	fi
+
+	# Check if GID is numeric
+	if ! echo "${CLAMAV_GID}" | grep -qE '^[0-9]+$'; then
+		echo "ERROR: CLAMAV_GID must be numeric, got: ${CLAMAV_GID}" >&2
+		return 1
+	fi
+
+	# Check UID is not 0 (root)
+	if [ "${CLAMAV_UID}" -eq 0 ]; then
+		echo "ERROR: CLAMAV_UID cannot be 0 (root)" >&2
+		return 1
+	fi
+
+	# Check GID is not 0 (root)
+	if [ "${CLAMAV_GID}" -eq 0 ]; then
+		echo "ERROR: CLAMAV_GID cannot be 0 (root)" >&2
+		return 1
+	fi
+
+	# Check UID/GID are within reasonable range
+	if [ "${CLAMAV_UID}" -gt 65535 ]; then
+		echo "WARNING: CLAMAV_UID ${CLAMAV_UID} is unusually high (> 65535)" >&2
+	fi
+
+	if [ "${CLAMAV_GID}" -gt 65535 ]; then
+		echo "WARNING: CLAMAV_GID ${CLAMAV_GID} is unusually high (> 65535)" >&2
+	fi
+
+	return 0
+}
+
+# Setup clamav user/group with custom UID/GID if needed
+setup_clamav_user() {
+	# Only modify if different from default (1000)
+	if [ "${CLAMAV_UID}" != "1000" ] || [ "${CLAMAV_GID}" != "1000" ]; then
+		echo "INFO: Reconfiguring clamav user: UID=${CLAMAV_UID}, GID=${CLAMAV_GID}"
+
+		# Validate first
+		validate_uid_gid || return 1
+
+		# Modify user UID if needed
+		if [ "${CLAMAV_UID}" != "1000" ]; then
+			usermod -u "${CLAMAV_UID}" clamav || {
+				echo "ERROR: Failed to set clamav user UID to ${CLAMAV_UID}" >&2
+				return 1
+			}
+		fi
+
+		# Modify group GID if needed
+		if [ "${CLAMAV_GID}" != "1000" ]; then
+			groupmod -g "${CLAMAV_GID}" clamav || {
+				echo "ERROR: Failed to set clamav group GID to ${CLAMAV_GID}" >&2
+				return 1
+			}
+		fi
+
+		echo "INFO: Successfully reconfigured clamav user with UID=${CLAMAV_UID}, GID=${CLAMAV_GID}"
+	else
+		echo "INFO: Using default clamav user: UID=1000, GID=1000"
+	fi
+}
+
+# Call setup function
+setup_clamav_user || exit 1
+
+# ============================================================================
+# End of UID/GID Configuration
+# ============================================================================
+
+
 if [ ! -d "/run/clamav" ]; then
-	install -d -g "clamav" -m 775 -o "clamav" "/run/clamav"
+	echo "INFO: Creating /run/clamav directory"
+	install -d -g "${CLAMAV_GID}" -m 775 -o "${CLAMAV_UID}" "/run/clamav"
+else
+	echo "INFO: Fixing ownership of /run/clamav directory"
+	chown "${CLAMAV_UID}:${CLAMAV_GID}" "/run/clamav"
+	chmod 775 "/run/clamav"
 fi
 
-# Assign ownership to the database directory, just in case it is a mounted volume
-chown -R clamav:clamav /var/lib/clamav
+# Ensure /var/log/clamav exists before chowning
+if [ ! -d "/var/log/clamav" ]; then
+    install -d -m 755 -g "${CLAMAV_GID}" -o "${CLAMAV_UID}" "/var/log/clamav"
+fi
+chown -R "${CLAMAV_UID}:${CLAMAV_GID}" /var/lib/clamav /var/log/clamav
 
 # configure freshclam.conf and clamd.conf from env variables if present
 env | grep "^CLAMD_CONF_" | while IFS="=" read -r KEY VALUE; do
@@ -71,7 +164,7 @@ else
 		          --daemon \
 		          --foreground \
 		          --stdout \
-		          --user="clamav" \
+		          --user="${CLAMAV_UID}" \
 			  &
 	fi
 

--- a/clamav/README-alpine.md
+++ b/clamav/README-alpine.md
@@ -546,3 +546,32 @@ You might do something along these lines:
        docker exec -it clam_container_02 clamdscan --reload; \
    fi
    ```
+
+## User and Permissions Management
+
+### UID/GID Customization and Permissions
+
+- The container supports runtime override of the ClamAV user and group IDs using the environment variables `CLAMAV_UID` and `CLAMAV_GID`.
+- Example usage:
+  ```sh
+  docker run -e CLAMAV_UID=2000 -e CLAMAV_GID=2000 clamav/clamav:1.5-alpine
+  ```
+- At startup, the entrypoint script will:
+  - Update the `clamav` user and group to the specified UID/GID.
+  - Ensure `/var/lib/clamav`, `/var/log/clamav`, and `/run/clamav` exist and are owned by the correct user/group.
+  - This ensures ClamAV can read/write its database and logs, even if you mount volumes over these directories.
+
+### Running as Non-root
+
+- If you run the container with `--user`, you are responsible for ensuring all necessary directories are writable by that user.
+- The entrypoint script cannot change ownership if not running as root.
+- Example:
+  ```sh
+  docker run --user 2000:2000 -v /my/log:/var/log/clamav clamav/clamav:1.5-alpine
+  ```
+- If you mount volumes, ensure the host directories exist and are writable by the container user.
+
+### Robust Directory Handling
+
+- The entrypoint script will create `/var/log/clamav` at runtime if it does not exist (e.g., if a volume is mounted over it).
+- Ownership is always set to the runtime UID/GID, ensuring no permission errors.

--- a/clamav/README-debian.md
+++ b/clamav/README-debian.md
@@ -556,3 +556,33 @@ You might do something along these lines:
        docker exec -it clam_container_02 clamdscan --reload; \
    fi
    ```
+
+## User and Permissions Management
+
+### UID/GID Customization and Permissions
+
+- The container supports runtime override of the ClamAV user and group IDs using the environment variables `CLAMAV_UID` and `CLAMAV_GID`.
+- Example usage:
+  ```sh
+  docker run -e CLAMAV_UID=2000 -e CLAMAV_GID=2000 clamav/clamav-debian:1.5
+  ```
+- At startup, the entrypoint script will:
+  - Update the `clamav` user and group to the specified UID/GID.
+  - Ensure `/var/lib/clamav`, `/var/log/clamav`, and `/run/clamav` exist and are owned by the correct user/group.
+  - This ensures ClamAV can read/write its database and logs, even if you mount volumes over these directories.
+
+### Running as Non-root
+
+- If you run the container with `--user`, you are responsible for ensuring all necessary directories are writable by that user.
+- The entrypoint script cannot change ownership if not running as root.
+- Example:
+  ```sh
+  docker run --user 2000:2000 -v /my/log:/var/log/clamav clamav/clamav-debian:1.5
+  ```
+- If you mount volumes, ensure the host directories exist and are writable by the container user.
+
+### Robust Directory Handling
+
+- The entrypoint script will create `/var/log/clamav` at runtime if it does not exist (e.g., if a volume is mounted over it).
+- Ownership is always set to the runtime UID/GID, ensuring no permission errors.
+

--- a/clamav/unstable/debian/scripts/docker-entrypoint-unprivileged.sh
+++ b/clamav/unstable/debian/scripts/docker-entrypoint-unprivileged.sh
@@ -10,6 +10,41 @@
 
 set -eu
 
+# ============================================================================
+# UID/GID Detection for Unprivileged Mode
+# ============================================================================
+# This script runs as non-root, so we cannot create/modify users
+# The clamav user must already exist (created by docker-entrypoint.sh or Dockerfile)
+# We detect the actual UID/GID from the existing user
+
+if ! id "clamav" > /dev/null 2>&1; then
+	echo "ERROR: clamav user does not exist!" >&2
+	echo "" >&2
+	echo "This unprivileged entrypoint requires the clamav user to already exist." >&2
+	echo "" >&2
+	echo "Solutions:" >&2
+	echo "  1. Use the privileged entrypoint (default):" >&2
+	echo "     docker run <image>" >&2
+	echo "" >&2
+	echo "  2. Use privileged entrypoint with custom UID/GID:" >&2
+	echo "     docker run -e CLAMAV_UID=2000 -e CLAMAV_GID=2000 <image>" >&2
+	echo "" >&2
+	echo "  3. Use unprivileged entrypoint after running privileged setup:" >&2
+	echo "     docker run --entrypoint /init <image>" >&2
+	exit 1
+fi
+
+# Get actual UID/GID from existing clamav user
+CLAMAV_UID=$(id -u clamav)
+CLAMAV_GID=$(id -g clamav)
+
+echo "INFO: Running as unprivileged user: clamav (UID=${CLAMAV_UID}, GID=${CLAMAV_GID})"
+
+# ============================================================================
+# End of UID/GID Detection
+# ============================================================================
+
+
 # run command if it is not starting with a "-" and is an executable in PATH
 if [ "${#}" -gt 0 ] && \
    [ "${1#-}" = "${1}" ] && \
@@ -27,7 +62,6 @@ else
 	# Ensure we have some virus data, otherwise clamd refuses to start
 	if [ ! -f "/var/lib/clamav/main.cvd" ]; then
 		echo "Updating initial database"
-		
 		# Set "TestDatabases no" and remove "NotifyClamd" for initial download
 		sed -e 's|^\(TestDatabases \)|\#\1|' \
 			-e '$a TestDatabases no' \
@@ -44,7 +78,7 @@ else
 		          --daemon \
 		          --foreground \
 		          --stdout \
-		          --user="clamav" \
+		          --user="${CLAMAV_UID}" \
 			  &
 	fi
 

--- a/clamav/unstable/debian/scripts/docker-entrypoint.sh
+++ b/clamav/unstable/debian/scripts/docker-entrypoint.sh
@@ -10,12 +10,105 @@
 
 set -eu
 
+# ============================================================================
+# UID/GID Configuration Support
+# ============================================================================
+# Allow runtime override of UID/GID via environment variables
+# Default values match the Dockerfile (1000 for Debian)
+CLAMAV_UID="${CLAMAV_UID:-1000}"
+CLAMAV_GID="${CLAMAV_GID:-1000}"
+
+# Validation function for UID/GID
+validate_uid_gid() {
+	# Check if UID is numeric
+	if ! echo "${CLAMAV_UID}" | grep -qE '^[0-9]+$'; then
+		echo "ERROR: CLAMAV_UID must be numeric, got: ${CLAMAV_UID}" >&2
+		return 1
+	fi
+
+	# Check if GID is numeric
+	if ! echo "${CLAMAV_GID}" | grep -qE '^[0-9]+$'; then
+		echo "ERROR: CLAMAV_GID must be numeric, got: ${CLAMAV_GID}" >&2
+		return 1
+	fi
+
+	# Check UID is not 0 (root)
+	if [ "${CLAMAV_UID}" -eq 0 ]; then
+		echo "ERROR: CLAMAV_UID cannot be 0 (root)" >&2
+		return 1
+	fi
+
+	# Check GID is not 0 (root)
+	if [ "${CLAMAV_GID}" -eq 0 ]; then
+		echo "ERROR: CLAMAV_GID cannot be 0 (root)" >&2
+		return 1
+	fi
+
+	# Check UID/GID are within reasonable range
+	if [ "${CLAMAV_UID}" -gt 65535 ]; then
+		echo "WARNING: CLAMAV_UID ${CLAMAV_UID} is unusually high (> 65535)" >&2
+	fi
+
+	if [ "${CLAMAV_GID}" -gt 65535 ]; then
+		echo "WARNING: CLAMAV_GID ${CLAMAV_GID} is unusually high (> 65535)" >&2
+	fi
+
+	return 0
+}
+
+# Setup clamav user/group with custom UID/GID if needed
+setup_clamav_user() {
+	# Only modify if different from default (1000)
+	if [ "${CLAMAV_UID}" != "1000" ] || [ "${CLAMAV_GID}" != "1000" ]; then
+		echo "INFO: Reconfiguring clamav user: UID=${CLAMAV_UID}, GID=${CLAMAV_GID}"
+
+		# Validate first
+		validate_uid_gid || return 1
+
+		# Modify user UID if needed
+		if [ "${CLAMAV_UID}" != "1000" ]; then
+			usermod -u "${CLAMAV_UID}" clamav || {
+				echo "ERROR: Failed to set clamav user UID to ${CLAMAV_UID}" >&2
+				return 1
+			}
+		fi
+
+		# Modify group GID if needed
+		if [ "${CLAMAV_GID}" != "1000" ]; then
+			groupmod -g "${CLAMAV_GID}" clamav || {
+				echo "ERROR: Failed to set clamav group GID to ${CLAMAV_GID}" >&2
+				return 1
+			}
+		fi
+
+		echo "INFO: Successfully reconfigured clamav user with UID=${CLAMAV_UID}, GID=${CLAMAV_GID}"
+	else
+		echo "INFO: Using default clamav user: UID=1000, GID=1000"
+	fi
+}
+
+# Call setup function
+setup_clamav_user || exit 1
+
+# ============================================================================
+# End of UID/GID Configuration
+# ============================================================================
+
+
 if [ ! -d "/run/clamav" ]; then
-	install -d -g "clamav" -m 775 -o "clamav" "/run/clamav"
+	echo "INFO: Creating /run/clamav directory"
+	install -d -g "${CLAMAV_GID}" -m 775 -o "${CLAMAV_UID}" "/run/clamav"
+else
+	echo "INFO: Fixing ownership of /run/clamav directory"
+	chown "${CLAMAV_UID}:${CLAMAV_GID}" "/run/clamav"
+	chmod 775 "/run/clamav"
 fi
 
-# Assign ownership to the database directory, just in case it is a mounted volume
-chown -R clamav:clamav /var/lib/clamav
+# Ensure /var/log/clamav exists before chowning
+if [ ! -d "/var/log/clamav" ]; then
+    install -d -m 755 -g "${CLAMAV_GID}" -o "${CLAMAV_UID}" "/var/log/clamav"
+fi
+chown -R "${CLAMAV_UID}:${CLAMAV_GID}" /var/lib/clamav /var/log/clamav
 
 # configure freshclam.conf and clamd.conf from env variables if present
 env | grep "^CLAMD_CONF_" | while IFS="=" read -r KEY VALUE; do
@@ -55,7 +148,6 @@ else
 	# Ensure we have some virus data, otherwise clamd refuses to start
 	if [ ! -f "/var/lib/clamav/main.cvd" ]; then
 		echo "Updating initial database"
-		
 		# Set "TestDatabases no" and remove "NotifyClamd" for initial download
 		sed -e 's|^\(TestDatabases \)|\#\1|' \
 			-e '$a TestDatabases no' \
@@ -72,7 +164,7 @@ else
 		          --daemon \
 		          --foreground \
 		          --stdout \
-		          --user="clamav" \
+		          --user="${CLAMAV_UID}" \
 			  &
 	fi
 


### PR DESCRIPTION
- Adding option to set GID/UID at runtime for privileged(root) run.
- Added permission to necessary files to runtime GID/UID set by user
- Added a debug to print GID/UID for unprivileged runs

Supersedes #12 
Closes #12 