### PR TITLE
CLAM-2975 - Sync tags in AWS ECR & Docker hub

### DIFF
--- a/clamav/1.0/debian/Jenkinsfile
+++ b/clamav/1.0/debian/Jenkinsfile
@@ -99,6 +99,7 @@ node('docker-buildx') {
                 //
 
                 // Build X.Y.Z-R_base image.
+
                 sh """
                     docker buildx build --no-cache --platform linux/amd64,linux/arm64,linux/ppc64le \
                         --build-arg BASE_IMAGE=${FULL_BASE_IMAGE} \
@@ -112,6 +113,10 @@ node('docker-buildx') {
                         --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE} \
@@ -125,7 +130,11 @@ node('docker-buildx') {
                     sh """
                         docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable_base-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest_base-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
 
                         docker buildx imagetools create ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
                             --tag ${params.ECR_PUBLIC_REPO}:stable_base-${params.BASE_IMAGE} \
@@ -154,6 +163,10 @@ node('docker-buildx') {
                         --build-arg BASE_IMAGE=${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}-${params.BASE_IMAGE} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FEATURE_VERSION}-${params.BASE_IMAGE} \
@@ -172,7 +185,11 @@ node('docker-buildx') {
                     sh """
                         docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
 
                         docker buildx imagetools create ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}-${params.BASE_IMAGE} \
                             --tag ${params.ECR_PUBLIC_REPO}:stable-${params.BASE_IMAGE} \

--- a/clamav/1.0/debian/Jenkinsfile
+++ b/clamav/1.0/debian/Jenkinsfile
@@ -113,10 +113,10 @@ node('docker-buildx') {
                         --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FULL_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE} \
@@ -131,10 +131,10 @@ node('docker-buildx') {
                         docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable_base-${params.BASE_IMAGE} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest_base-${params.BASE_IMAGE} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:stable_base-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:stable_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:latest_base-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:latest_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
 
                         docker buildx imagetools create ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
                             --tag ${params.ECR_PUBLIC_REPO}:stable_base-${params.BASE_IMAGE} \
@@ -163,10 +163,10 @@ node('docker-buildx') {
                         --build-arg BASE_IMAGE=${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}-${params.BASE_IMAGE} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}-${params.BASE_IMAGE} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FULL_VERSION}-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FULL_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FEATURE_VERSION}-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FEATURE_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}-${params.BASE_IMAGE} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FEATURE_VERSION}-${params.BASE_IMAGE} \
@@ -186,10 +186,10 @@ node('docker-buildx') {
                         docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable-${params.BASE_IMAGE} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest-${params.BASE_IMAGE} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:stable-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:stable-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:latest-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:latest-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
 
                         docker buildx imagetools create ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}-${params.BASE_IMAGE} \
                             --tag ${params.ECR_PUBLIC_REPO}:stable-${params.BASE_IMAGE} \

--- a/clamav/1.4/debian/Jenkinsfile
+++ b/clamav/1.4/debian/Jenkinsfile
@@ -113,10 +113,10 @@ node('docker-buildx') {
                         --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FULL_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE} \
@@ -131,10 +131,10 @@ node('docker-buildx') {
                         docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable_base-${params.BASE_IMAGE} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest_base-${params.BASE_IMAGE} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:stable_base-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:stable_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:latest_base-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:latest_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
 
                         docker buildx imagetools create ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
                             --tag ${params.ECR_PUBLIC_REPO}:stable_base-${params.BASE_IMAGE} \
@@ -163,10 +163,10 @@ node('docker-buildx') {
                         --build-arg BASE_IMAGE=${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}-${params.BASE_IMAGE} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}-${params.BASE_IMAGE} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FULL_VERSION}-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FULL_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FEATURE_VERSION}-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FEATURE_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}-${params.BASE_IMAGE} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FEATURE_VERSION}-${params.BASE_IMAGE} \
@@ -186,10 +186,10 @@ node('docker-buildx') {
                         docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable-${params.BASE_IMAGE} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest-${params.BASE_IMAGE} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:stable-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:stable-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:latest-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:latest-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
 
                         docker buildx imagetools create ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}-${params.BASE_IMAGE} \
                             --tag ${params.ECR_PUBLIC_REPO}:stable-${params.BASE_IMAGE} \

--- a/clamav/1.4/debian/Jenkinsfile
+++ b/clamav/1.4/debian/Jenkinsfile
@@ -12,9 +12,9 @@ properties([
         booleanParam(name: 'IS_LATEST', defaultValue: false,                                        description: 'If "true", will also publish to :latest, and :stable tags.'),
         string(name: 'ECR_PUBLIC_REPO', defaultValue: 'public.ecr.aws/cisco/clamav/clamav',      description: 'ClamAV AWS Public ECR repo'),
         string(name: 'AWS_CREDENTIALS_ID', defaultValue: 'pinkhat-clamav-aws-creds', description: 'Vault path for AWS creds'),
-        string(name: 'BASE_IMAGE', defaultValue: 'debian', description: 'Codename for Debian base image'),
-        string(name: 'BASE_IMAGE_VERSION', defaultValue: '13', description: 'Codename for Debian base image'),
-        string(name: 'BASE_IMAGE_VARIANT', defaultValue: 'slim', description: 'Codename for Debian base image')
+        string(name: 'BASE_IMAGE', defaultValue: 'debian', description: 'Debian base image'),
+        string(name: 'BASE_IMAGE_VERSION', defaultValue: '13', description: 'Version for Debian base image'),
+        string(name: 'BASE_IMAGE_VARIANT', defaultValue: 'slim', description: 'Variant for Debian base image')
 
     ]),
     disableConcurrentBuilds(),
@@ -113,6 +113,10 @@ node('docker-buildx') {
                         --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE} \
@@ -126,7 +130,11 @@ node('docker-buildx') {
                     sh """
                         docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable_base-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest_base-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
 
                         docker buildx imagetools create ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
                             --tag ${params.ECR_PUBLIC_REPO}:stable_base-${params.BASE_IMAGE} \
@@ -155,6 +163,10 @@ node('docker-buildx') {
                         --build-arg BASE_IMAGE=${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}-${params.BASE_IMAGE} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FEATURE_VERSION}-${params.BASE_IMAGE} \
@@ -173,7 +185,11 @@ node('docker-buildx') {
                     sh """
                         docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
 
                         docker buildx imagetools create ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}-${params.BASE_IMAGE} \
                             --tag ${params.ECR_PUBLIC_REPO}:stable-${params.BASE_IMAGE} \

--- a/clamav/1.5/debian/Jenkinsfile
+++ b/clamav/1.5/debian/Jenkinsfile
@@ -113,10 +113,10 @@ node('docker-buildx') {
                         --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FULL_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE} \
@@ -131,10 +131,10 @@ node('docker-buildx') {
                         docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable_base-${params.BASE_IMAGE} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest_base-${params.BASE_IMAGE} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:stable_base-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:stable_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:latest_base-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:latest_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
 
                         docker buildx imagetools create ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
                             --tag ${params.ECR_PUBLIC_REPO}:stable_base-${params.BASE_IMAGE} \
@@ -163,10 +163,10 @@ node('docker-buildx') {
                         --build-arg BASE_IMAGE=${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}-${params.BASE_IMAGE} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}-${params.BASE_IMAGE} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FULL_VERSION}-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FULL_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FEATURE_VERSION}-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:${params.FEATURE_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}-${params.BASE_IMAGE} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FEATURE_VERSION}-${params.BASE_IMAGE} \
@@ -186,10 +186,10 @@ node('docker-buildx') {
                         docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable-${params.BASE_IMAGE} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest-${params.BASE_IMAGE} \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:stable-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:stable-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:latest-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:latest-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
 
                         docker buildx imagetools create ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}-${params.BASE_IMAGE} \
                             --tag ${params.ECR_PUBLIC_REPO}:stable-${params.BASE_IMAGE} \

--- a/clamav/1.5/debian/Jenkinsfile
+++ b/clamav/1.5/debian/Jenkinsfile
@@ -12,9 +12,9 @@ properties([
         booleanParam(name: 'IS_LATEST', defaultValue: true,                                         description: 'If "true", will also publish to :latest, and :stable tags.'),
         string(name: 'ECR_PUBLIC_REPO', defaultValue: 'public.ecr.aws/cisco/clamav/clamav',      description: 'ClamAV AWS Public ECR repo'),
         string(name: 'AWS_CREDENTIALS_ID', defaultValue: 'pinkhat-clamav-aws-creds', description: 'Vault path for AWS creds'),
-        string(name: 'BASE_IMAGE', defaultValue: 'debian', description: 'Codename for Debian base image'),
-        string(name: 'BASE_IMAGE_VERSION', defaultValue: '13', description: 'Codename for Debian base image'),
-        string(name: 'BASE_IMAGE_VARIANT', defaultValue: 'slim', description: 'Codename for Debian base image')
+        string(name: 'BASE_IMAGE', defaultValue: 'debian', description: 'Debian base image'),
+        string(name: 'BASE_IMAGE_VERSION', defaultValue: '13', description: 'Version for Debian base image'),
+        string(name: 'BASE_IMAGE_VARIANT', defaultValue: 'slim', description: 'Variant for Debian base image')
 
     ]),
     disableConcurrentBuilds(),
@@ -113,6 +113,10 @@ node('docker-buildx') {
                         --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION}_base \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FEATURE_VERSION}_base-${params.BASE_IMAGE} \
@@ -126,7 +130,11 @@ node('docker-buildx') {
                     sh """
                         docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable_base \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest_base \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable_base-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest_base-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
 
                         docker buildx imagetools create ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}_base-${params.BASE_IMAGE} \
                             --tag ${params.ECR_PUBLIC_REPO}:stable_base-${params.BASE_IMAGE} \
@@ -155,6 +163,10 @@ node('docker-buildx') {
                         --build-arg BASE_IMAGE=${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION}_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FEATURE_VERSION} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FULL_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:${params.FEATURE_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}-${params.BASE_IMAGE} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:${params.FEATURE_VERSION}-${params.BASE_IMAGE} \
@@ -173,7 +185,11 @@ node('docker-buildx') {
                     sh """
                         docker buildx imagetools create ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:${params.FULL_VERSION} \
                             --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:stable \
-                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:latest \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:stable-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest-${params.BASE_IMAGE} \
+                            --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.NAMESPACE}:latest-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
 
                         docker buildx imagetools create ${params.ECR_PUBLIC_REPO}:${params.FULL_VERSION}-${params.BASE_IMAGE} \
                             --tag ${params.ECR_PUBLIC_REPO}:stable-${params.BASE_IMAGE} \

--- a/clamav/unstable/debian/Jenkinsfile
+++ b/clamav/unstable/debian/Jenkinsfile
@@ -97,8 +97,8 @@ node('docker-buildx') {
                         --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
                         --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/$${params.NAMESPACE}:unstable_base-${params.BASE_IMAGE} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/$${params.NAMESPACE}:unstable_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:unstable_base-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:unstable_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:unstable_base-${params.BASE_IMAGE} \
                         --tag ${params.ECR_PUBLIC_REPO}:unstable_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
                         --rm --push .
@@ -123,8 +123,8 @@ node('docker-buildx') {
                         --push \
                         --build-arg BASE_IMAGE=${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/$${params.NAMESPACE}:unstable-${params.BASE_IMAGE} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/$${params.NAMESPACE}:unstable-${params.BASE_IMAGE}$ \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:unstable-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:unstable-${params.BASE_IMAGE}$ \
                         --tag ${params.ECR_PUBLIC_REPO}:unstable-${params.BASE_IMAGE} \
                         --tag ${params.ECR_PUBLIC_REPO}:unstable-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         -f Dockerfile.add-db .

--- a/clamav/unstable/debian/Jenkinsfile
+++ b/clamav/unstable/debian/Jenkinsfile
@@ -100,7 +100,7 @@ node('docker-buildx') {
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:unstable_base-${params.BASE_IMAGE} \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:unstable_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:unstable_base-${params.BASE_IMAGE} \
-                        --tag ${params.ECR_PUBLIC_REPO}:unstable_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
+                        --tag ${params.ECR_PUBLIC_REPO}:unstable_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --rm --push .
                 """
 

--- a/clamav/unstable/debian/Jenkinsfile
+++ b/clamav/unstable/debian/Jenkinsfile
@@ -124,7 +124,6 @@ node('docker-buildx') {
                         --build-arg BASE_IMAGE=${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:unstable-${params.BASE_IMAGE} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:unstable-${params.BASE_IMAGE} \
                         --tag ${params.ECR_PUBLIC_REPO}:unstable-${params.BASE_IMAGE} \
                         --tag ${params.ECR_PUBLIC_REPO}:unstable-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         -f Dockerfile.add-db .

--- a/clamav/unstable/debian/Jenkinsfile
+++ b/clamav/unstable/debian/Jenkinsfile
@@ -124,7 +124,7 @@ node('docker-buildx') {
                         --build-arg BASE_IMAGE=${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:unstable-${params.BASE_IMAGE} \
-                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:unstable-${params.BASE_IMAGE}$ \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:unstable-${params.BASE_IMAGE} \
                         --tag ${params.ECR_PUBLIC_REPO}:unstable-${params.BASE_IMAGE} \
                         --tag ${params.ECR_PUBLIC_REPO}:unstable-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         -f Dockerfile.add-db .

--- a/clamav/unstable/debian/Jenkinsfile
+++ b/clamav/unstable/debian/Jenkinsfile
@@ -124,6 +124,7 @@ node('docker-buildx') {
                         --build-arg BASE_IMAGE=${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:unstable-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/clamav:unstable-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         --tag ${params.ECR_PUBLIC_REPO}:unstable-${params.BASE_IMAGE} \
                         --tag ${params.ECR_PUBLIC_REPO}:unstable-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         -f Dockerfile.add-db .

--- a/clamav/unstable/debian/Jenkinsfile
+++ b/clamav/unstable/debian/Jenkinsfile
@@ -1,11 +1,11 @@
 properties([
     parameters([
-        string(name: 'DOCKER_REGISTRY', defaultValue: "docker.io",                                  description: 'The Docker registry to use'),
-        string(name: 'REGISTRY_CREDS',  defaultValue: "dockerhub",                                  description: 'The Jenkins credentials ID for the given registry'),
-        string(name: 'WEBEX_SPACE_ID',  defaultValue: "b204c1a0-6862-11e8-9dbc-93ef3cfef186",       description: 'ID of Webex space to push pass/fail notifications'),
-        string(name: 'NAMESPACE',       defaultValue: "clamav",                                     description: 'The docker namespace to use'),
-        string(name: 'IMAGE_NAME',      defaultValue: "clamav-debian",                              description: 'The docker image name to use'),
-        string(name: 'REPOSITORY',      defaultValue: "https://github.com/Cisco-Talos/clamav.git",  description: 'The repository from which to build'),
+        string(name: 'DOCKER_REGISTRY', defaultValue: 'docker.io',                                  description: 'The Docker registry to use'),
+        string(name: 'REGISTRY_CREDS',  defaultValue: 'dockerhub',                                  description: 'The Jenkins credentials ID for the given registry'),
+        string(name: 'WEBEX_SPACE_ID',  defaultValue: 'b204c1a0-6862-11e8-9dbc-93ef3cfef186',       description: 'ID of Webex space to push pass/fail notifications'),
+        string(name: 'NAMESPACE',       defaultValue: 'clamav',                                     description: 'The docker namespace to use'),
+        string(name: 'IMAGE_NAME',      defaultValue: 'clamav-debian',                              description: 'The docker image name to use'),
+        string(name: 'REPOSITORY',      defaultValue: 'https://github.com/Cisco-Talos/clamav.git',  description: 'The repository from which to build'),
         string(name: 'ECR_PUBLIC_REPO', defaultValue: 'public.ecr.aws/cisco/clamav/clamav',      description: 'ClamAV AWS Public ECR repo'),
         string(name: 'AWS_CREDENTIALS_ID', defaultValue: 'pinkhat-clamav-aws-creds', description: 'Vault path for AWS creds'),
         string(name: 'BASE_IMAGE', defaultValue: 'debian', description: 'Debian base image'),
@@ -97,7 +97,10 @@ node('docker-buildx') {
                         --annotation org.opencontainers.image.ref.name=${params.BRANCH} \
                         --annotation org.opencontainers.image.created="\$(date -Iseconds)" \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base \
-                        --tag ${params.ECR_PUBLIC_REPO}:unstable_base \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/$${params.NAMESPACE}:unstable_base-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/$${params.NAMESPACE}:unstable_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
+                        --tag ${params.ECR_PUBLIC_REPO}:unstable_base-${params.BASE_IMAGE} \
+                        --tag ${params.ECR_PUBLIC_REPO}:unstable_base-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT}
                         --rm --push .
                 """
 
@@ -120,7 +123,10 @@ node('docker-buildx') {
                         --push \
                         --build-arg BASE_IMAGE=${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable_base \
                         --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/${params.IMAGE_NAME}:unstable \
-                        --tag ${params.ECR_PUBLIC_REPO}:unstable \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/$${params.NAMESPACE}:unstable-${params.BASE_IMAGE} \
+                        --tag ${params.DOCKER_REGISTRY}/${params.NAMESPACE}/$${params.NAMESPACE}:unstable-${params.BASE_IMAGE}$ \
+                        --tag ${params.ECR_PUBLIC_REPO}:unstable-${params.BASE_IMAGE} \
+                        --tag ${params.ECR_PUBLIC_REPO}:unstable-${params.BASE_IMAGE}${params.BASE_IMAGE_VERSION}-${params.BASE_IMAGE_VARIANT} \
                         -f Dockerfile.add-db .
                 """
             }


### PR DESCRIPTION
- Adding Debian base image tags in clamav/clamav repo.
- This is to sync image tags same as what we have in AWS ECR clamav:clamav repo.
- clamav/clamav-debain repo images will remain unchanged.