### PR TITLE
Increase debian ctest timeout

### DIFF
--- a/clamav/1.4/debian/Dockerfile
+++ b/clamav/1.4/debian/Dockerfile
@@ -92,7 +92,7 @@ RUN apt update && apt install -y \
         "/clamav/etc/clamav/clamav-milter.conf.sample" > "/clamav/etc/clamav/clamav-milter.conf" || \
     exit 1 \
     && \
-    ctest -V --timeout 3000
+    ctest -V --timeout 5000
 
 FROM index.docker.io/library/${BASE_IMAGE}
 

--- a/clamav/1.5/debian/Dockerfile
+++ b/clamav/1.5/debian/Dockerfile
@@ -92,7 +92,7 @@ RUN apt update && apt install -y \
         "/clamav/etc/clamav/clamav-milter.conf.sample" > "/clamav/etc/clamav/clamav-milter.conf" || \
     exit 1 \
     && \
-    ctest -V --timeout 3000
+    ctest -V --timeout 5000
 
 FROM index.docker.io/library/${BASE_IMAGE}
 

--- a/clamav/unstable/debian/Dockerfile
+++ b/clamav/unstable/debian/Dockerfile
@@ -92,7 +92,7 @@ RUN apt update && apt install -y \
         "/clamav/etc/clamav/clamav-milter.conf.sample" > "/clamav/etc/clamav/clamav-milter.conf" || \
     exit 1 \
     && \
-    ctest -V --timeout 3000
+    ctest -V --timeout 5000
 
 FROM index.docker.io/library/${BASE_IMAGE}
 


### PR DESCRIPTION
The newly added clamav tests are causing test timeouts under QEMU.