### PR TITLE
Skip QEMU-sensitive quarantine race tests in Docker builds

### DIFF
--- a/clamav/1.4/debian/Dockerfile
+++ b/clamav/1.4/debian/Dockerfile
@@ -92,7 +92,8 @@ RUN apt update && apt install -y \
         "/clamav/etc/clamav/clamav-milter.conf.sample" > "/clamav/etc/clamav/clamav-milter.conf" || \
     exit 1 \
     && \
-    ctest -V --timeout 3000
+    PYTEST_ADDOPTS="-k 'not quarantine_directory_replacement'" \
+        ctest -V --timeout 3000
 
 FROM index.docker.io/library/${BASE_IMAGE}
 

--- a/clamav/1.5/debian/Dockerfile
+++ b/clamav/1.5/debian/Dockerfile
@@ -92,7 +92,8 @@ RUN apt update && apt install -y \
         "/clamav/etc/clamav/clamav-milter.conf.sample" > "/clamav/etc/clamav/clamav-milter.conf" || \
     exit 1 \
     && \
-    ctest -V --timeout 3000
+    PYTEST_ADDOPTS="-k 'not quarantine_directory_replacement'" \
+        ctest -V --timeout 3000
 
 FROM index.docker.io/library/${BASE_IMAGE}
 


### PR DESCRIPTION
## Summary

The Debian 1.4 and 1.5 image builds run the ClamAV feature tests during the
builder stage. After the CLAM-2959 quarantine TOCTOU tests were added to the
released source branches, multi-arch Docker builds can time out under QEMU while
running the destination directory replacement tests.

Those tests intentionally pad the HDB database with a large number of synthetic
signatures to create a reliable race window. Under emulated arm64/ppc64le
builds, the inner pytest subprocess timeout can expire before `clamscan`
finishes even though the outer CTest timeout is still high enough.

## Changes

Set `PYTEST_ADDOPTS` for the Debian 1.4 and 1.5 Dockerfile builder-stage test
runs so pytest excludes tests whose names contain
`quarantine_directory_replacement`.

This skips only these QEMU-sensitive race-window tests in Docker image builds:

- `test_quarantine_directory_replacement_does_not_redirect_copy_target`
- `test_quarantine_directory_replacement_does_not_redirect_move_target`

The rest of the CTest and pytest suite still runs during the image build.

## Validation

- `git diff --check`
- Inspected the generated Dockerfile command shape locally

I did not run a full multi-architecture Docker build locally.
